### PR TITLE
Allow to specifiy a particular xdebug revision to checkout in install_xdebug.

### DIFF
--- a/share/php-build/plugins.d/xdebug.sh
+++ b/share/php-build/plugins.d/xdebug.sh
@@ -5,6 +5,7 @@
 function install_xdebug_master {
     local source_dir="$TMP/source/xdebug-master"
     local cwd=$(pwd)
+    local revision=$1
 
     if [ -d "$source_dir" ] && [ -d "$source_dir/.git" ]; then
         log "XDebug" "Updating XDebug from Git Master"
@@ -14,6 +15,13 @@ function install_xdebug_master {
     else
         log "XDebug" "Fetching from Git Master"
         git clone git://github.com/derickr/xdebug.git "$source_dir" > /dev/null
+    fi
+
+    if [ -n "$revision" ]; then
+        log "XDebug" "Checkout specified revision: $revision"
+        cd "$source_dir"
+        git reset --hard $revision
+        cd "$cwd"
     fi
 
     _build_xdebug "$source_dir"


### PR DESCRIPTION
We could then pin xdebug to a known to be working revision for a particular version's definition.

@michaelklishin add an issue today, when building travis VMs, where the current xdebug master was not compiling against one of the php version we support on Travis. This would would allow us to pin a particular xdebug revision in our definitions to avoid bad surprises :)
