### PR TITLE
remove $LOG_DIR

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,6 @@ echo -n "  - Creating Directories..."
 echo " Done."
 
 chmod -R 0777 "$TMP_DIR"
-chmod -R 0777 "$LOG_DIR"
 
 echo -n "  - Copying files..."
 cp -R "$DIR/"{bin,share} "$PREFIX/"


### PR DESCRIPTION
`chmod -R 0777 "$LOG_DIR"`

This command occurs error "chmod: cannot access : No such file or directory" as `$LOG_DIR` is not defined.
