### PR TITLE
Add comment out on extension_dir in php.ini. especially for php5.2.

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -278,6 +278,10 @@ function build_package {
             fi
         fi
     fi
+    if [ -f "$PREFIX/etc/php.ini" ]; then
+        sed -i -E 's/^(extension_dir)/; \1/g' "$PREFIX/etc/php.ini"
+    fi
+
 }
 
 # Definition commands


### PR DESCRIPTION
Comment out at extension_dir in php.ini.
php.ini-dist and php.ini-recommend (this is default php.ini on php5.2) has `extension_dir = "./"`. This causes extension load error, like this.https://github.com/travis-ci/travis-cookbooks/pull/57
If undef extension_dir in php.ini, then automatically(?) completed.
After php5.3 default is commented out extension_dir. 
