### PR TITLE
pre-installation patches

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -193,7 +193,6 @@ function download {
     local archive_type=${package_file##*.}
 
     "extract_$archive_type" "$package_file" "$TMP/source/$DEFINITION"
-    cd "$TMP/source/$DEFINITION"
 }
 
 function extract_gz {
@@ -299,7 +298,9 @@ function install_package {
 
     {
         download $url
+        cd "$TMP/source/$DEFINITION"
         build_package
+        cd - > /dev/null
     } >&4 2>&1
 }
 


### PR DESCRIPTION
I wanted to compile php 5.2.17 on Ubuntu 11.10. 
My current definition file is as follows:

```

configure_option "--enable-fastcgi"

configure_option -R "--with-mysql"
configure_option -R "--with-mysqli"
configure_option -R "--with-pdo-mysql"

configure_option -D "--with-gd"
# apply path: git apply -p1 ~/Dropbox/Archivio/php-build/debian_patches_disable_SSLv2_for_openssl_1_0_0.patch
configure_option -D "--with-openssl"

# disable apache, needs (root) write access to /usr/lib/apache2/modules/ and we use fastcgi anyway
#configure_option -R "--with-apxs2=/usr/bin/apxs2"

# needs patch ~/Dropbox/Archivio/php-build/php-5.2.17-fpm-0.5.14.diff.gz
configure_option -R "--enable-fpm"
#configure_option -R "--disable-cgi"

configure_option -D "--with-curl=/usr"
configure_option -D "--with-curl"

with_pear

install_package "http://museum.php.net/php5/php-5.2.17.tar.bz2"
install_xdebug "2.1.3"
```

As you can see I need to apply 2 patches (one for fpm and one for the openssl library, see https://bugs.php.net/bug.php?id=54736)

Would you be interested in a "pre-installation" patch command (shell function)?
I think I can implement it but I don't want to start if there's no interest :)

Cheers
