### PR TITLE
Fix readme. humanshell/php-build no longer exists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ as a plugin:
 
     $ mkdir -p ~/.phpenv/plugins
     $ cd ~/.phpenv/plugins
-    $ git clone git://github.com/humanshell/php-build.git
+    $ git clone git://github.com/CHH/php-build.git
 
 ## Changelog
 


### PR DESCRIPTION
Fix readme.
