### PR TITLE
Remove plugins description

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,6 @@ To install php-build to an other location than `/usr/local` set the
 If you don't have permissions to write to the prefix, then you 
 have to run `install.sh` as superuser, either via `su -c` or via `sudo`.
 
-If you only intend to use php-build via
-[phpenv](https://github.com/humanshell/phpenv) then you can install it locally
-as a plugin:
-
-    $ mkdir -p ~/.phpenv/plugins
-    $ cd ~/.phpenv/plugins
-    $ git clone git://github.com/CHH/php-build.git
-
 ## Changelog
 
 ### v0.7.0


### PR DESCRIPTION
humanshell/phpenv now has own phpenv-install command.
So if you install CHH/php-build into humanshell/phpenv plugin directory, you can not use
phpenv install command.

see below:
Issue #1: libexec/phpenv-install and php-build's phpenv-install have same name · humanshell/phpenv https://github.com/humanshell/phpenv/issues/1
