### PR TITLE
add rbenv-install for working as plugin to CHH's phpenv

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
+# Provide rbenv completions
+if [ "$1" = "--complete" ]; then
+  exec php-build --definitions
+fi
+
+if [ -z "$RBENV_ROOT" ]; then
+  RBENV_ROOT="${HOME}/.phpenv"
+fi
+
+DEFINITION="$1"
+case "$DEFINITION" in
+"" | -* )
+  { echo "usage: phpenv install VERSION"
+    echo
+    echo "Available versions:"
+    php-build --definitions | sed 's/^/ /'
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+VERSION_NAME="${DEFINITION##*/}"
+PREFIX="${RBENV_ROOT}/versions/${VERSION_NAME}"
+
+php-build "$DEFINITION" "$PREFIX"
+phpenv rehash


### PR DESCRIPTION
I am using CHH/phpenv. Thank you for helpful tool.

However, "phpenv install" is not supported between CHH/phpenv and CHH/php-build.

So this request adds rbenv-install for "phpenv install".
It is almost same as https://gist.github.com/1305922, except Line 11.
