### PR TITLE
Create configure file.

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -436,6 +436,11 @@ function configure_package {
         argv="$argv --with-libdir=lib64"
     fi
 
+    # Create configure file, because source does not have this.
+    if [ ! -f "./configure" ]; then
+      ./buildconf > /dev/null
+    fi
+
     ./configure $argv > /dev/null
 
     cd "$backup_pwd"


### PR DESCRIPTION
This create ./configure file.
Released php tarball include ./configure file, but repository source code does not have configure one.
This is first step for install from source.

Memo:
Some file can install by this patch, but some can not install.
https://gist.github.com/3073436
