### PR TITLE
Fixed a legibility issue reading the error message

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -449,7 +449,7 @@ function build_error {
         echo "Here are the last 10 lines from the log:"
         echo
         echo "-----------------------------------------"
-        echo $(tail -n 10 "$LOG_PATH")
+        echo "$(tail -n 10 "$LOG_PATH")"
         echo "-----------------------------------------"
         echo
         echo "The full Log is available at '${LOG_PATH}'."


### PR DESCRIPTION
There was an `echo` that should have double quotes to display new lines as new lines and not new lines as spaces.
