### PR TITLE
Avoid installing PHP binary as "php.dSYM" on MacOSX 10.7 and 10.8

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -432,6 +432,13 @@ function configure_package {
         argv="$argv --with-libdir=lib64"
     fi
 
+    # Avoid installing PHP binary as "php.dSYM" on MacOSX 10.7 and 10.8.
+    # PHP 5.2 and 5.3 has the problem.
+    # See https://github.com/php/php-src/pull/135
+    if is_osx; then
+        export ac_cv_exeext=''
+    fi
+
     ./configure $argv > /dev/null
 
     cd "$backup_pwd"


### PR DESCRIPTION
When building PHP 5.2 and 5.3 on my MacOSX 10.7, PHP binary is installed as "php.dSYM".

Though php-build renames the binary name to "php" after building PHP, some commands know older name. For instance, `php-config --php-binary' returns $HOME/.phpenv/versions/5.3.16/bin/php.dSYM.

This is PHP's bug, discussed at https://github.com/php/php-src/pull/135.
