### PR TITLE
Fix issue with PEAR's php_ini config. 

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -415,7 +415,7 @@ function with_pear {
 }
 
 function pear_setup {
-    "$PREFIX/bin/pear" config-set php_ini "$PREFIX/etc/php.ini"
+    "$PREFIX/bin/pear" config-set php_ini "$PREFIX/etc/php.ini" system
 }
 
 function with_apxs2 {


### PR DESCRIPTION
The config was set for the user in ~/.pearrc and was overwritten by each
new PHP version installed: the value pointed to the php.ini of the last
PHP version installed.

The solution was to set the config for the "system layer" which is
version specific in our case.
