### PR TITLE
Fix extension's path to relative one in apc.ini

### DIFF
--- a/share/php-build/plugins.d/apc.sh
+++ b/share/php-build/plugins.d/apc.sh
@@ -52,12 +52,10 @@ function _build_apc {
 
     local apc_ini="$PREFIX/etc/conf.d/apc.ini"
 
-    local extension_dir=$("$PREFIX/bin/php" -r "echo ini_get('extension_dir');")
-
     if [ ! -f "$apc_ini" ]; then
         log "APC" "Installing APC configuration in $apc_ini"
 
-        echo "extension=\"$extension_dir/apc.so\"" > $apc_ini
+        echo "extension=\"apc.so\"" > $apc_ini
 
     fi
 


### PR DESCRIPTION
PHP < 5.3.0 doesn't support "extension=(absolute path)" style in php.ini (see: https://bugs.php.net/bug.php?id=41310). Considering PHP 5.2.17+APC, "extension=(relative path)" style is better.
