### PR TITLE
Use "php-config" instead of "php" to get extension_dir path

### DIFF
--- a/share/php-build/plugins.d/xdebug.sh
+++ b/share/php-build/plugins.d/xdebug.sh
@@ -78,7 +78,7 @@ function _build_xdebug {
 
     # Zend extensions are not looked up in PHP's extension dir, so
     # we need to find the absolute path for the extension_dir.
-    local extension_dir=$("$PREFIX/bin/php" -r "echo ini_get('extension_dir');")
+    local extension_dir=$("$PREFIX/bin/php-config" --extension-dir)
 
     if [ -z "$PHP_BUILD_XDEBUG_ENABLE" ]; then
         PHP_BUILD_XDEBUG_ENABLE=yes


### PR DESCRIPTION
To create xdebug.ini, current xdebug.sh requires "php" command to get extension_dir. However, we can't always have "php". For example, when building php-fpm only, there's no "php". "php-config" is much better for this purpose, which is installed with all SAPI. 
