### PR TITLE
Install apache module into user's libexec dir

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -529,12 +529,17 @@ function configure_package {
     local argv="--with-config-file-path="$PREFIX/etc" \
 --with-config-file-scan-dir="$PREFIX/etc/conf.d" \
 --prefix=$PREFIX \
+--libexecdir=$PREFIX/libexec \
 $CONFIGURE_OPTIONS"
 
     log "Preparing" "$source_path"
 
     if [ ! -d "$PREFIX/etc/conf.d" ]; then
         mkdir -p "$PREFIX/etc/conf.d"
+    fi
+
+    if [ ! -d "$PREFIX/libexec" ]; then
+        mkdir -p "$PREFIX/libexec"
     fi
 
     # Set the lib dir to `lib64` on **x86_64**
@@ -557,6 +562,17 @@ $CONFIGURE_OPTIONS"
     fi
 
     ./configure $argv > /dev/null
+
+    # Use php-build prefix for the Apache libexec folder
+    cat <<EOF | patch -N -p1 -s || true
+*** 5.2.17-orig/Makefile 2012-11-26 19:10:33.000000000 +0900
+--- 5.2.17/Makefile 2012-11-26 19:11:53.000000000 +0900
+***************
+*** 105 ****
+! INSTALL_IT = \$(mkinstalldirs) '\$(INSTALL_ROOT)/usr/libexec/apache2' && \$(mkinstalldirs) '\$(INSTALL_ROOT)/private/etc/apache2' && /usr/sbin/apxs -S LIBEXECDIR='\$(INSTALL_ROOT)/usr/libexec/apache2' -S SYSCONFDIR='\$(INSTALL_ROOT)/private/etc/apache2' -i -a -n php5 libs/libphp5.so
+--- 105 ----
+! INSTALL_IT = \$(mkinstalldirs) '$PREFIX/libexec/apache2' && \$(mkinstalldirs) '\$(INSTALL_ROOT)/private/etc/apache2' && /usr/sbin/apxs -S LIBEXECDIR='$PREFIX/libexec/apache2' -S SYSCONFDIR='\$(INSTALL_ROOT)/private/etc/apache2' -i -a -n php5 libs/libphp5.so
+EOF
 
     cd "$backup_pwd"
 }


### PR DESCRIPTION
I tried php-build with "with_apxs2", then I got following errors.

```
/usr/share/httpd/build/instdso.sh SH_LIBTOOL='/usr/share/apr-1/build-1/libtool' libs/libphp5.so /usr/libexec/apache2
cp: /usr/libexec/apache2/libphp5.so: Permission denied
apxs:Error: Command failed with rc=65536
.
make: *** [install-sapi] Error 1
```

Of cource I can install apache module by typing "sudo php-build", however i think it's not expected behavior.

Not only PHP binaries but also Apache module should be installed to user's directory such as "5.4.13/libexec/apache2/libphp5.so". This PR changes libexec path to user's directory.
