### PR TITLE
Return TMP to "/var/tmp" on Mac OS X

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -85,7 +85,7 @@ function realpath {
 # is treated as the base for the `share/` and `tmp/`
 # folders of php-build.
 PHP_BUILD_ROOT="$(realpath "$0")/.."
-TMP="$(dirname $(mktemp --dry-run 2>/dev/null || echo "/var/tmp/tmp_dir"))/php-build"
+TMP="$(dirname $(mktemp --dry-run 2>/dev/null || echo "/var/tmp"))/php-build"
 
 # This file gets copied to `$PREFIX/etc/php.ini` once
 # the build is complete. This is by default the PHP tarball's


### PR DESCRIPTION
The fallback on 34b6d01b9898d730aeda0a954f81d15412a8fb8d has changed TMP to "var/tmp/tmp_dir.

This commit tries to assign TMP, on Mac OS X, as before then 5c62a3d71051e94aa5215e77461116b822dc7cc8.
