### PR TITLE
Revert PR #123 (change to TMP on Mac OS X)

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -85,7 +85,7 @@ function realpath {
 # is treated as the base for the `share/` and `tmp/`
 # folders of php-build.
 PHP_BUILD_ROOT="$(realpath "$0")/.."
-TMP="$(dirname $(mktemp --dry-run 2>/dev/null || echo "/var/tmp"))/php-build"
+TMP="$(dirname $(mktemp --dry-run 2>/dev/null || echo "/var/tmp/tmp_dir"))/php-build"
 
 # This file gets copied to `$PREFIX/etc/php.ini` once
 # the build is complete. This is by default the PHP tarball's


### PR DESCRIPTION
Wrong commit on PR #123 screwed things.

This commit reverts that change. My bad :-(
## 

This time, besides TravisCI, I ran the tests on my machine as well:

```
$ uname -a
Darwin Rogerios-MacBook-Pro-2.local 12.3.0 Darwin Kernel Version 12.3.0: Sun Jan  6 22:37:10 PST 2013; root:xnu-2050.22.13~1/RELEASE_X86_64 x86_64

$ /usr/bin/sw_vers
ProductName:    Mac OS X
ProductVersion: 10.8.3
BuildVersion:   12D78

$ ./run-tests.sh stable
Testing definitions 5.3.25 5.4.15

Building '5.3.25'...OK
Running Tests...
1..4
ok 1 Enables pear auto_discover
ok 2 Installs pyrus executable
ok 3 Installs xdebug.so
ok 4 Enables XDebug
Building '5.4.15'...OK
Running Tests...
1..4
ok 1 Enables pear auto_discover
ok 2 Installs pyrus executable
ok 3 Installs xdebug.so
ok 4 Enables XDebug
```
