### PR TITLE
Create a temp loop in order to bypass travis-ci 10 minutes build timeout

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -36,6 +36,8 @@ esac
 echo "Testing definitions $BUILD_LIST"
 echo
 
+while true; do echo "..."; sleep 60; done & #https://github.com/CHH/php-build/issues/134
+
 for definition in $BUILD_LIST; do
     echo -n "Building '$definition'..."
     if ./bin/php-build --pear "$definition" "$BUILD_PREFIX/$definition" &> /dev/null; then
@@ -50,6 +52,8 @@ for definition in $BUILD_LIST; do
         FAILED="$FAILED $definition"
     fi
 done
+
+kill %1 #https://github.com/CHH/php-build/issues/134
 
 if [ -z "$FAILED" ]; then
     rm -rf "$BUILD_PREFIX"


### PR DESCRIPTION
Fix #134
