### PR TITLE
fix definition 5.5snapshot and add master

### DIFF
--- a/share/php-build/definitions/5.5snapshot
+++ b/share/php-build/definitions/5.5snapshot
@@ -1,3 +1,4 @@
-install_package_from_github master
+install_package "http://snaps.php.net/php5.5-latest.tar.bz2"
 install_pyrus
-install_xdebug_master
+install_xdebug "2.2.3"
+enable_builtin_opcache

--- a/share/php-build/definitions/master
+++ b/share/php-build/definitions/master
@@ -1,0 +1,4 @@
+install_package_from_github master
+install_pyrus
+install_xdebug_master
+enable_builtin_opcache


### PR DESCRIPTION
5.5snapshot is currently building 5.6-dev from github master, so I changed it to build the 5.5 snapshot from php.net, also added the master definition to build from github master.
