### PR TITLE
Fix package URL for PHP 5.3.8

### DIFF
--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.8.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.8.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"


### PR DESCRIPTION
404 Not Found on http://www.php.net/distributions/php-5.3.8.tar.bz2
