### PR TITLE
Updated Definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
     - DEFINITION=5.3.28
-    - DEFINITION=5.4.25
-    - DEFINITION=5.5.9
+    - DEFINITION=5.4.26
+    - DEFINITION=5.5.10
 
 script: ./run-tests.sh $DEFINITION
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Update this when a new stable version comes around
-STABLE_DEFINITIONS="5.3.28 5.4.25 5.5.9"
+STABLE_DEFINITIONS="5.3.28 5.4.26 5.5.10"
 
 TIME="$(date "+%Y%m%d%H%M%S")"
 

--- a/share/php-build/definitions/5.4.26
+++ b/share/php-build/definitions/5.4.26
@@ -1,0 +1,3 @@
+install_package "http://php.net/distributions/php-5.4.26.tar.bz2"
+install_pyrus
+install_xdebug "2.2.4"

--- a/share/php-build/definitions/5.4snapshot
+++ b/share/php-build/definitions/5.4snapshot
@@ -1,3 +1,3 @@
 install_package "http://snaps.php.net/php5.4-latest.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.4"

--- a/share/php-build/definitions/5.5.10
+++ b/share/php-build/definitions/5.5.10
@@ -1,0 +1,4 @@
+install_package "http://www.php.net/distributions/php-5.5.10.tar.bz2"
+install_pyrus
+install_xdebug "2.2.4"
+enable_builtin_opcache

--- a/share/php-build/definitions/5.5snapshot
+++ b/share/php-build/definitions/5.5snapshot
@@ -1,4 +1,4 @@
 install_package "http://snaps.php.net/php5.5-latest.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.4"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6snapshot
+++ b/share/php-build/definitions/5.6snapshot
@@ -1,0 +1,4 @@
+install_package "http://snaps.php.net/php5.6-latest.tar.bz2"
+install_pyrus
+install_xdebug "2.2.4"
+enable_builtin_opcache


### PR DESCRIPTION
I've added php 5.4.26 and 5.5.10 definitions with the new xdebug 2.2.4, and updated the test config for this. I've also updated the 5.4 and 5.5 snapshot definitions for xdebug 2.2.4 and added a missing php 5.6 snapshot definition.

FYI, the releases were tagged today: https://github.com/php/php-src/releases.
