### PR TITLE
Avoid overwriting apache module installed into user's libexec dir

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -354,14 +354,15 @@ function build_package {
 
     trigger_before_install 2>&4
 
+    if [ -n "$APXS" ]; then
+        _LIBEXECDIR=`$APXS -q LIBEXECDIR`
+        sed -i"" -e "s|LIBEXECDIR='\$(INSTALL_ROOT)$_LIBEXECDIR'|LIBEXECDIR=$PREFIX/libexec|" $source_path/Makefile
+    fi
+
     log "Compiling" "$source_path"
 
     cd "$source_path"
     {
-        if [ -n $APXS ]; then
-            _LIBEXECDIR=`$APXS -q LIBEXECDIR`
-            sed -i"" -e "s|LIBEXECDIR='\$(INSTALL_ROOT)$_LIBEXECDIR'|LIBEXECDIR=$PREFIX/libexec|" $TMP/source/$DEFINITION/Makefile
-        fi
         make
         make install
         make clean


### PR DESCRIPTION
This patch is for avoiding to overwrite apache php module. The apache php module is installed to the libexec directory of each version with "with_apxs2" options.

```
e.g.) /path/to/phpenv/versions/5.X.XX/libexec/libphp5.so
```
