### PR TITLE
Update 5.4.14 Package Location

### DIFF
--- a/share/php-build/definitions/5.4.14
+++ b/share/php-build/definitions/5.4.14
@@ -1,3 +1,3 @@
-install_package "http://php.net/distributions/php-5.4.14.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.14.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"


### PR DESCRIPTION
Error with 5.4.14:
curl: (22) The requested URL returned error: 404 Not Found

The releases page details a different location for 5.4.14: http://us2.php.net/releases/
