### PR TITLE
Added phpenv plugin version installation manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Now you can use php-build as phpenv plugin, as follows:
 
 The built version will be installed into ``$HOME/.phpenv/versions/<definition>``.
 
-### Use phpenv only
+### Use php-build only
 
 Clone the Git Repository:
 


### PR DESCRIPTION
I believe that many people use php-build with phpenv.
So I've added manual to README, to install php-build as phpenv plugin.
I think this is useful for that people.
