### PR TITLE
Updates most of the broken php urls

### DIFF
--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.10.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.10.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.11.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.11.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.12.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.12.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.13.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.13.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.14.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.14.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.15.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.15.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.16.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.16.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.3.17
+++ b/share/php-build/definitions/5.3.17
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.17.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.17.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.3.18
+++ b/share/php-build/definitions/5.3.18
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.18.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.18.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.3.20
+++ b/share/php-build/definitions/5.3.20
@@ -1,3 +1,3 @@
-install_package "http://php.net/distributions/php-5.3.20.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.20.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.3.21
+++ b/share/php-build/definitions/5.3.21
@@ -1,3 +1,3 @@
-install_package "http://php.net/distributions/php-5.3.21.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.21.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.3.22
+++ b/share/php-build/definitions/5.3.22
@@ -1,3 +1,3 @@
-install_package "http://php.net/distributions/php-5.3.22.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.22.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.8.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.8.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.3.9.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.3.9.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0
+++ b/share/php-build/definitions/5.4.0
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.4.0.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.0.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0RC1
+++ b/share/php-build/definitions/5.4.0RC1
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.0RC1.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0RC1.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0RC2
+++ b/share/php-build/definitions/5.4.0RC2
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.0RC2.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0RC2.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0RC3
+++ b/share/php-build/definitions/5.4.0RC3
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.0RC3.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0RC3.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0RC4
+++ b/share/php-build/definitions/5.4.0RC4
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.0RC4.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0RC4.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0RC5
+++ b/share/php-build/definitions/5.4.0RC5
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.0RC5.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0RC5.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0RC6
+++ b/share/php-build/definitions/5.4.0RC6
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.0RC6.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0RC6.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0RC7
+++ b/share/php-build/definitions/5.4.0RC7
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.0RC7.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0RC7.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0RC8
+++ b/share/php-build/definitions/5.4.0RC8
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.0RC8.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0RC8.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0alpha3
+++ b/share/php-build/definitions/5.4.0alpha3
@@ -1,4 +1,4 @@
 
-install_package "http://downloads.php.net/stas/php-5.4.0alpha3.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0alpha3.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0beta1
+++ b/share/php-build/definitions/5.4.0beta1
@@ -1,4 +1,4 @@
 
-install_package "http://downloads.php.net/stas/php-5.4.0beta1.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0beta1.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.0beta2
+++ b/share/php-build/definitions/5.4.0beta2
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.0beta2.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.0beta2.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.1
+++ b/share/php-build/definitions/5.4.1
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.4.1.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.1.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.10
+++ b/share/php-build/definitions/5.4.10
@@ -1,3 +1,3 @@
-install_package "http://php.net/distributions/php-5.4.10.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.10.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.4.11
+++ b/share/php-build/definitions/5.4.11
@@ -1,3 +1,3 @@
-install_package "http://php.net/distributions/php-5.4.11.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.11.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.4.12
+++ b/share/php-build/definitions/5.4.12
@@ -1,3 +1,3 @@
-install_package "http://php.net/distributions/php-5.4.12.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.12.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.4.2
+++ b/share/php-build/definitions/5.4.2
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.4.2.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.2.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.3
+++ b/share/php-build/definitions/5.4.3
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.4.3.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.3.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.4
+++ b/share/php-build/definitions/5.4.4
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.4.4.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.4.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.5
+++ b/share/php-build/definitions/5.4.5
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.4.5.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.5.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.6
+++ b/share/php-build/definitions/5.4.6
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.4.6.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.6.tar.bz2"
 install_pyrus
 install_xdebug "2.2.0"

--- a/share/php-build/definitions/5.4.7
+++ b/share/php-build/definitions/5.4.7
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.4.7.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.7.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.4.8
+++ b/share/php-build/definitions/5.4.8
@@ -1,3 +1,3 @@
-install_package "http://www.php.net/distributions/php-5.4.8.tar.bz2"
+install_package "http://museum.php.net/php5/php-5.4.8.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"

--- a/share/php-build/definitions/5.4.9RC1
+++ b/share/php-build/definitions/5.4.9RC1
@@ -1,3 +1,3 @@
-install_package "http://downloads.php.net/stas/php-5.4.9RC1.tar.bz2"
+install_package "http://downloads.php.net/stas/old/php-5.4.9RC1.tar.bz2"
 install_pyrus
 install_xdebug "2.2.1"


### PR DESCRIPTION
I was unable to find any url replacements for:

http://downloads.php.net/stas/php-5.4.10RC1.tar.bz2
http://downloads.php.net/stas/php-5.4.1RC1.tar.bz2
http://downloads.php.net/stas/php-5.4.1RC2.tar.bz2

For the curious, the script I used to do the replacements is here (requires some familiarity with Clojure): https://gist.github.com/dwwoelfel/8a6944191cbd659665a0
