### PR TITLE
Upgrade xdebug

### DIFF
--- a/share/php-build/definitions/5.2.17
+++ b/share/php-build/definitions/5.2.17
@@ -8,4 +8,4 @@ configure_option -R "--with-pdo-mysql"
 with_pear
 
 install_package "http://museum.php.net/php5/php-5.2.17.tar.bz2"
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.10.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.11.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.12.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.13.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.14.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.15.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.16.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.17
+++ b/share/php-build/definitions/5.3.17
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.17.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.18
+++ b/share/php-build/definitions/5.3.18
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.18.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.19
+++ b/share/php-build/definitions/5.3.19
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/johannes/php-5.3.19.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.2.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.20
+++ b/share/php-build/definitions/5.3.20
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.20.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.21
+++ b/share/php-build/definitions/5.3.21
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.21.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.22
+++ b/share/php-build/definitions/5.3.22
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.22.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.23
+++ b/share/php-build/definitions/5.3.23
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.23.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.24
+++ b/share/php-build/definitions/5.3.24
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.24.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.25
+++ b/share/php-build/definitions/5.3.25
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.25.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.26
+++ b/share/php-build/definitions/5.3.26
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.26.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.27
+++ b/share/php-build/definitions/5.3.27
@@ -1,3 +1,3 @@
 install_package "http://php.net/distributions/php-5.3.27.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.28
+++ b/share/php-build/definitions/5.3.28
@@ -1,3 +1,3 @@
 install_package "http://php.net/distributions/php-5.3.28.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.3.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.6.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.8.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.3.9.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0
+++ b/share/php-build/definitions/5.4.0
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.0.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC1
+++ b/share/php-build/definitions/5.4.0RC1
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0RC1.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC2
+++ b/share/php-build/definitions/5.4.0RC2
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0RC2.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC3
+++ b/share/php-build/definitions/5.4.0RC3
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0RC3.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC4
+++ b/share/php-build/definitions/5.4.0RC4
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0RC4.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC5
+++ b/share/php-build/definitions/5.4.0RC5
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0RC5.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC6
+++ b/share/php-build/definitions/5.4.0RC6
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0RC6.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC7
+++ b/share/php-build/definitions/5.4.0RC7
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0RC7.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC8
+++ b/share/php-build/definitions/5.4.0RC8
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0RC8.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0beta1
+++ b/share/php-build/definitions/5.4.0beta1
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0beta1.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0beta2
+++ b/share/php-build/definitions/5.4.0beta2
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/old/php-5.4.0beta2.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.1
+++ b/share/php-build/definitions/5.4.1
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.1.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.10
+++ b/share/php-build/definitions/5.4.10
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.10.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.11
+++ b/share/php-build/definitions/5.4.11
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.11.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.12
+++ b/share/php-build/definitions/5.4.12
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.12.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.13
+++ b/share/php-build/definitions/5.4.13
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.13.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.14
+++ b/share/php-build/definitions/5.4.14
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.14.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.15
+++ b/share/php-build/definitions/5.4.15
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.15.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.16
+++ b/share/php-build/definitions/5.4.16
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.16.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.17
+++ b/share/php-build/definitions/5.4.17
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.17.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.18
+++ b/share/php-build/definitions/5.4.18
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.18.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.19
+++ b/share/php-build/definitions/5.4.19
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.19.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.2
+++ b/share/php-build/definitions/5.4.2
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.2.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.20
+++ b/share/php-build/definitions/5.4.20
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.20.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.21
+++ b/share/php-build/definitions/5.4.21
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.21.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.22
+++ b/share/php-build/definitions/5.4.22
@@ -1,3 +1,3 @@
 install_package "http://php.net/distributions/php-5.4.22.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.23
+++ b/share/php-build/definitions/5.4.23
@@ -1,3 +1,3 @@
 install_package "http://php.net/distributions/php-5.4.23.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.24
+++ b/share/php-build/definitions/5.4.24
@@ -1,3 +1,3 @@
 install_package "http://php.net/distributions/php-5.4.24.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.25
+++ b/share/php-build/definitions/5.4.25
@@ -1,3 +1,3 @@
 install_package "http://php.net/distributions/php-5.4.25.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.26
+++ b/share/php-build/definitions/5.4.26
@@ -1,3 +1,3 @@
 install_package "http://php.net/distributions/php-5.4.26.tar.bz2"
 install_pyrus
-install_xdebug "2.2.4"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.27
+++ b/share/php-build/definitions/5.4.27
@@ -1,3 +1,3 @@
 install_package "http://php.net/distributions/php-5.4.27.tar.bz2"
 install_pyrus
-install_xdebug "2.2.4"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.3
+++ b/share/php-build/definitions/5.4.3
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.3.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.4
+++ b/share/php-build/definitions/5.4.4
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.4.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.5
+++ b/share/php-build/definitions/5.4.5
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.5.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.6
+++ b/share/php-build/definitions/5.4.6
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.6.tar.bz2"
 install_pyrus
-install_xdebug "2.2.0"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.7
+++ b/share/php-build/definitions/5.4.7
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.7.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.8
+++ b/share/php-build/definitions/5.4.8
@@ -1,3 +1,3 @@
 install_package "http://museum.php.net/php5/php-5.4.8.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.9
+++ b/share/php-build/definitions/5.4.9
@@ -1,3 +1,3 @@
 install_package "http://downloads.php.net/stas/php-5.4.9.tar.bz2"
 install_pyrus
-install_xdebug "2.2.1"
+install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.5.0
+++ b/share/php-build/definitions/5.5.0
@@ -1,4 +1,4 @@
 install_package "http://museum.php.net/php5/php-5.5.0.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.1
+++ b/share/php-build/definitions/5.5.1
@@ -1,4 +1,4 @@
 install_package "http://museum.php.net/php5/php-5.5.1.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.10
+++ b/share/php-build/definitions/5.5.10
@@ -1,4 +1,4 @@
 install_package "http://php.net/distributions/php-5.5.10.tar.bz2"
 install_pyrus
-install_xdebug "2.2.4"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.11
+++ b/share/php-build/definitions/5.5.11
@@ -1,4 +1,4 @@
 install_package "http://php.net/distributions/php-5.5.11.tar.bz2"
 install_pyrus
-install_xdebug "2.2.4"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.2
+++ b/share/php-build/definitions/5.5.2
@@ -1,4 +1,4 @@
 install_package "http://museum.php.net/php5/php-5.5.2.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.3
+++ b/share/php-build/definitions/5.5.3
@@ -1,4 +1,4 @@
 install_package "http://museum.php.net/php5/php-5.5.3.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.4
+++ b/share/php-build/definitions/5.5.4
@@ -1,4 +1,4 @@
 install_package "http://museum.php.net/php5/php-5.5.4.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.5
+++ b/share/php-build/definitions/5.5.5
@@ -1,4 +1,4 @@
 install_package "http://php.net/distributions/php-5.5.5.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.6
+++ b/share/php-build/definitions/5.5.6
@@ -1,4 +1,4 @@
 install_package "http://php.net/distributions/php-5.5.6.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.7
+++ b/share/php-build/definitions/5.5.7
@@ -1,4 +1,4 @@
 install_package "http://php.net/distributions/php-5.5.7.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.8
+++ b/share/php-build/definitions/5.5.8
@@ -1,4 +1,4 @@
 install_package "http://php.net/distributions/php-5.5.8.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.9
+++ b/share/php-build/definitions/5.5.9
@@ -1,4 +1,4 @@
 install_package "http://php.net/distributions/php-5.5.9.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.0alpha1
+++ b/share/php-build/definitions/5.6.0alpha1
@@ -1,4 +1,4 @@
 install_package "http://downloads.php.net/tyrael/php-5.6.0alpha1.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.0alpha2
+++ b/share/php-build/definitions/5.6.0alpha2
@@ -1,4 +1,4 @@
 install_package "http://downloads.php.net/tyrael/php-5.6.0alpha2.tar.bz2"
 install_pyrus
-install_xdebug "2.2.3"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.0alpha3
+++ b/share/php-build/definitions/5.6.0alpha3
@@ -1,4 +1,4 @@
 install_package "http://downloads.php.net/tyrael/php-5.6.0alpha3.tar.bz2"
 install_pyrus
-install_xdebug "2.2.4"
+install_xdebug "2.2.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.0beta1
+++ b/share/php-build/definitions/5.6.0beta1
@@ -1,4 +1,4 @@
 install_package "http://downloads.php.net/tyrael/php-5.6.0beta1.tar.bz2"
 install_pyrus
-install_xdebug "2.2.4"
+install_xdebug "2.2.5"
 enable_builtin_opcache


### PR DESCRIPTION
Let's not use random old versions of xdebug. It would make more sense to just upgrade them all to the latest patch version 2.2.5.
