### PR TITLE
Added support for patching php source code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 env:
-    - DEFINITION=5.2.17
+    - DEFINITION=5.2.17 PHP_BUILD_CONFIGURE_OPTS="--with-libdir=lib/x86_64-linux-gnu"
+    - DEFINITION=5.3.3 PHP_BUILD_CONFIGURE_OPTS="--with-libdir=lib/x86_64-linux-gnu"
     - DEFINITION=5.3.29
     - DEFINITION=5.4.34
     - DEFINITION=5.5.18
@@ -10,7 +11,7 @@ script: ./run-tests.sh $DEFINITION
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get build-dep php5-cli
-    - sudo apt-get install -qq git-core libmcrypt-dev
+    - sudo apt-get install -qq git-core libmcrypt-dev libjpeg-dev libreadline-dev
 
 before_script:
     - git clone http://github.com/sstephenson/bats
@@ -20,7 +21,3 @@ before_script:
 
 after_failure:
     - sudo cat $(ls -r /tmp/php-build*.log | head -n 1)
-
-matrix:
-    allow_failures:
-        - env: DEFINITION=5.2.17

--- a/bin/php-build
+++ b/bin/php-build
@@ -101,6 +101,9 @@ PHP_DEFAULT_INI="php.ini-production"
 # These arguments are read from `share/php-build/default_configure_options`.
 CONFIGURE_OPTIONS=$(cat "$PHP_BUILD_ROOT/share/php-build/default_configure_options")
 
+# Patches to be applied at the source
+PATCH_FILES=""
+
 if [ -n "$PHP_BUILD_CONFIGURE_OPTS" ]; then
     CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $PHP_BUILD_CONFIGURE_OPTS"
 fi
@@ -373,6 +376,8 @@ function build_package {
 
     trigger_before_install 2>&4
 
+    apply_patches "$source_path" 2>&4
+
     log "Compiling" "$source_path"
 
     cd "$source_path"
@@ -406,6 +411,20 @@ function build_package {
     if [ -f "$PREFIX/etc/php.ini" ]; then
         sed -i.bak -e 's/^\(extension_dir\)/; \1/g' "$PREFIX/etc/php.ini"
         rm "$PREFIX/etc/php.ini.bak"
+    fi
+}
+
+# Apply patch files
+function apply_patches {
+    local source_path=$1
+    local patches_dir=$PHP_BUILD_ROOT/share/php-build/patches
+
+    if [ -n "$PATCH_FILES" ]; then
+        log "Info" "Applying patches: $PATCH_FILES"
+        for patch in $PATCH_FILES; do
+            local patch_file="$patches_dir/$patch"
+            patch -d "$source_path" -N -p1 -s < $patch_file || true
+        done
     fi
 }
 
@@ -483,6 +502,17 @@ function configure_option {
 
     if [ -n "$2" ]; then
         CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS=$2"
+    fi
+}
+
+# ### patch_file
+#
+# Add a patch to internal patch list
+function patch_file {
+    if [ -n "$PATCH_FILES" ]; then
+        PATCH_FILES="$PATCH_FILES $1"
+    else
+        PATCH_FILES="$1"
     fi
 }
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -45,6 +45,9 @@ for definition in $BUILD_LIST; do
 
         export TEST_PREFIX="$BUILD_PREFIX/$definition"
 
+        grep -e 'install_pyrus' "share/php-build/definitions/$definition" > /dev/null
+        export INSTALL_PYRUS=$?
+
         echo "Running Tests..."
         bats "tests/"
     else

--- a/share/php-build/definitions/5.2.17
+++ b/share/php-build/definitions/5.2.17
@@ -5,6 +5,10 @@ configure_option -R "--with-mysql"
 configure_option -R "--with-mysqli"
 configure_option -R "--with-pdo-mysql"
 
+patch_file "gmp.c.patch"
+patch_file "xp_ssl.c.patch"
+patch_file "zip_direct.c.patch"
+
 with_pear
 
 install_package "http://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.2.17.tar.bz2;h=90d654f7b9c60320f6228194ed1d2f12976a3a59;hb=bed93a30bbc2104f6e88e6ef142891a4c289502f"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -1,3 +1,7 @@
+patch_file "xp_ssl.c.patch"
+patch_file "zip_direct.c.patch"
+
 install_package "http://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.2.tar.bz2;h=69f6e396a0898af2d528d0826704460327191eee;hb=68deb8a9489af4c64ce4bb50e93db6328ddaf4e9"
 install_pyrus
 install_xdebug "2.2.5"
+

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -1,3 +1,6 @@
+patch_file "xp_ssl.c.patch"
+patch_file "zip_direct.c.patch"
+
 install_package "http://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.3.tar.bz2;h=c473d92b8399ed7dfc995864d8c0987041300a22;hb=b142c68a1bc6ef1eb24fc61fed1b4bf702b4751f"
 install_pyrus
 install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -1,3 +1,5 @@
+patch_file "xp_ssl.c.patch"
+
 install_package "http://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.6.tar.bz2;h=70fcfecaaa6c58d20a1a8080a7d68e111bb8f9ba;hb=ff4121c1cdebd9248ee7d5726e1abd8c0218cac9"
 install_pyrus
 install_xdebug "2.2.5"

--- a/share/php-build/patches/gmp.c.patch
+++ b/share/php-build/patches/gmp.c.patch
@@ -1,0 +1,15 @@
+Fix for a constant isn't defined on newer system in PHP < 5.3
+--- a/ext/gmp/gmp.c
++++ b/ext/gmp/gmp.c
+@@ -1396,8 +1396,11 @@
+ 
+ 		GMPG(rand_initialized) = 1;
+ 	}
++#ifdef GMP_LIMB_BITS
++	mpz_urandomb(*gmpnum_result, GMPG(rand_state), GMP_ABS (limiter) * GMP_LIMB_BITS);
++#else
+ 	mpz_urandomb(*gmpnum_result, GMPG(rand_state), GMP_ABS (limiter) * __GMP_BITS_PER_MP_LIMB);
+-
++#endif
+ 	ZEND_REGISTER_RESOURCE(return_value, gmpnum_result, le_gmp);
+ }

--- a/share/php-build/patches/xp_ssl.c.patch
+++ b/share/php-build/patches/xp_ssl.c.patch
@@ -1,0 +1,48 @@
+Fix for bug 54736 (https://bugs.php.net/bug.php?id=54736)
+This patch provides support for OpenSSL 1.0 in PHP < 5.3.8
+--- a/ext/openssl/xp_ssl.c
++++ b/ext/openssl/xp_ssl.c
+@@ -333,9 +333,14 @@
+ 			method = SSLv23_client_method();
+ 			break;
+ 		case STREAM_CRYPTO_METHOD_SSLv2_CLIENT:
++#ifdef OPENSSL_NO_SSL2
++			php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSLv2 support is not compiled into the OpenSSL library PHP is linked against");
++			return -1;
++#else
+ 			sslsock->is_client = 1;
+ 			method = SSLv2_client_method();
+ 			break;
++#endif
+ 		case STREAM_CRYPTO_METHOD_SSLv3_CLIENT:
+ 			sslsock->is_client = 1;
+ 			method = SSLv3_client_method();
+@@ -353,9 +358,14 @@
+ 			method = SSLv3_server_method();
+ 			break;
+ 		case STREAM_CRYPTO_METHOD_SSLv2_SERVER:
++#ifdef OPENSSL_NO_SSL2
++			php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSLv2 support is not compiled into the OpenSSL library PHP is linked against");
++			return -1;
++#else
+ 			sslsock->is_client = 0;
+ 			method = SSLv2_server_method();
+ 			break;
++#endif
+ 		case STREAM_CRYPTO_METHOD_TLS_SERVER:
+ 			sslsock->is_client = 0;
+ 			method = TLSv1_server_method();
+@@ -814,8 +824,13 @@
+ 		sslsock->enable_on_connect = 1;
+ 		sslsock->method = STREAM_CRYPTO_METHOD_SSLv23_CLIENT;
+ 	} else if (strncmp(proto, "sslv2", protolen) == 0) {
++#ifdef OPENSSL_NO_SSL2
++		php_error_docref(NULL TSRMLS_CC, E_WARNING, "SSLv2 support is not compiled into the OpenSSL library PHP is linked against");
++		return NULL;
++#else
+ 		sslsock->enable_on_connect = 1;
+ 		sslsock->method = STREAM_CRYPTO_METHOD_SSLv2_CLIENT;
++#endif
+ 	} else if (strncmp(proto, "sslv3", protolen) == 0) {
+ 		sslsock->enable_on_connect = 1;
+ 		sslsock->method = STREAM_CRYPTO_METHOD_SSLv3_CLIENT;

--- a/share/php-build/patches/zip_direct.c.patch
+++ b/share/php-build/patches/zip_direct.c.patch
@@ -1,0 +1,13 @@
+Wrong in ordering of arguments.
+PHP 5.3.6 the whole function call was removed
+--- a/ext/zip/lib/zip_dirent.c
++++ b/ext/zip/lib/zip_dirent.c
+@@ -475,7 +475,7 @@
+ {
+     struct tm tm;
+ 
+-    memset(&tm, sizeof(tm), 0);
++    memset(&tm, 0, sizeof(tm));
+     
+     /* let mktime decide if DST is in effect */
+     tm.tm_isdst = -1;

--- a/tests/pyrus.bats
+++ b/tests/pyrus.bats
@@ -1,6 +1,10 @@
 #!/usr/bin/env bats
 
 @test "Installs pyrus executable" {
+    if [ $INSTALL_PYRUS -ne 0 ]; then
+        skip "Pyrus wasn't configured to be installed by definition file"
+    fi
+
     [ -f "$TEST_PREFIX/bin/pyrus" ]
 }
 


### PR DESCRIPTION
I've added support for patching the php source code. This should allow PHP versions lower than 5.3.7 to be compiled on newer systems.

Which patches are beeing applied is defined by the definition file.
