### PR TITLE
[travis] Cat log errors in case of failure and include 5.2.17 in travis build but as an allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 env:
+    - DEFINITION=5.2.17
     - DEFINITION=5.3.29
     - DEFINITION=5.4.34
     - DEFINITION=5.5.18
@@ -19,3 +20,7 @@ before_script:
 
 after_failure:
     - sudo cat $(ls -r /tmp/php-build*.log | head -n 1)
+
+matrix:
+    allow_failures:
+        - env: DEFINITION=5.2.17


### PR DESCRIPTION
Include after_failure in travis to see log error is important when any build fail and it's not clear, just with Travis default log, what happened.

I think it will help the work of our contributors that want to fix directly whats is showed in build log errors directly in Travis.
## 

As 5.2.17 is the last one of 5.2 branch, it would be ok to have this tested as well despite of it isn't one of official supported version in php.net nowadays.

In order to don't break completely our build, if it fails, 5.2.17 is include in section `allow_failures` in Travis, keeping the build ok it the newer definitions goes ok as well.
