### PR TITLE
Removed the php53 snapshot since it's eol

### DIFF
--- a/share/php-build/definitions/5.3snapshot
+++ b/share/php-build/definitions/5.3snapshot
@@ -1,3 +1,0 @@
-install_package "http://snaps.php.net/php5.3-latest.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"


### PR DESCRIPTION
We don't have a php 5.2 snapshot, and I don't think we need a php 5.3 snapshot anymore either since they're both eol.
