### PR TITLE
Removed old php 5.4 definitions

### DIFF
--- a/share/php-build/definitions/5.4.0RC1
+++ b/share/php-build/definitions/5.4.0RC1
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0RC1.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC2
+++ b/share/php-build/definitions/5.4.0RC2
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0RC2.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC3
+++ b/share/php-build/definitions/5.4.0RC3
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0RC3.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC4
+++ b/share/php-build/definitions/5.4.0RC4
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0RC4.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC5
+++ b/share/php-build/definitions/5.4.0RC5
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0RC5.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC6
+++ b/share/php-build/definitions/5.4.0RC6
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0RC6.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC7
+++ b/share/php-build/definitions/5.4.0RC7
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0RC7.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0RC8
+++ b/share/php-build/definitions/5.4.0RC8
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0RC8.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0beta1
+++ b/share/php-build/definitions/5.4.0beta1
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0beta1.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"

--- a/share/php-build/definitions/5.4.0beta2
+++ b/share/php-build/definitions/5.4.0beta2
@@ -1,3 +1,0 @@
-install_package "http://downloads.php.net/stas/old/php-5.4.0beta2.tar.bz2"
-install_pyrus
-install_xdebug "2.2.5"


### PR DESCRIPTION
I don't think we really need these old php 5.4 pre-release versions, do we?
