### PR TITLE
Don't run php 5.2 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 env:
-    - DEFINITION=5.2.17 PHP_BUILD_CONFIGURE_OPTS="--with-libdir=lib/x86_64-linux-gnu"
     - DEFINITION=5.3.3 PHP_BUILD_CONFIGURE_OPTS="--with-libdir=lib/x86_64-linux-gnu"
     - DEFINITION=5.3.29
     - DEFINITION=5.4.34


### PR DESCRIPTION
Since travis can only 5 concurrent builds, I propose we ditch the php 5.2 build to half the time we have to wait for travis to go green.
