### PR TITLE
Update `download_from_github` function

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -231,34 +231,22 @@ function download_filename() {
     echo $filename
 }
 
-# Downloads a PHP Source Tarball from GitHub and extracts it to
+# Downloads a source from GitHub and extracts it to
 # `$TMP/source/$DEFINITION`.
 function download_from_github() {
     local branch=$1
     local repo=$2
-    local package_file="$TMP/packages/$branch.tar.gz"
-    local url="https://github.com/$repo/tarball/$branch"
-    local temp_package="$TMP/$branch.tar.gz"
+    local url="git://github.com/$repo.git"
+    local source_path="$TMP/source/$DEFINITION"
 
-    if [ -d "$TMP/source/$DEFINITION" ]; then
-        log "Removing" "Already downloaded and extracted $url"
-        rm -rf "$TMP/source/$DEFINITION"
+    if [ -d "$source_path" ]; then
+        log "Removing" "Already cloned $branch from $url"
+        rm -rf "$source_path"
     fi
 
-    log "Downloading" "$url"
+    log "Cloning" "Branch $branch from $url"
 
-    # Remove the temp file if one exists.
-    if [ -f "$temp_package" ]; then
-        rm "$temp_package"
-    fi
-
-    http get "$url" > $temp_package
-    cp "$temp_package" "$TMP/packages"
-    rm "$temp_package"
-
-    mkdir "$TMP/source/$DEFINITION"
-
-    extract_gz "$package_file" "$TMP/source/$DEFINITION"
+    git clone --branch="$branch" --depth=1 --quiet --recursive "$url" "$source_path" 2>&4
 }
 
 function extract_gz() {


### PR DESCRIPTION
Clones the repository and its submodules instead of download the tarball from GitHub.

***
I was starting to work on HHVM implementation, but it's necessary to update the `configure_package` function with a lot of things and I don't think I'm gonna have time to do it now.
I decided to send this pull request because maybe it can be useful for another person.