### PR TITLE
Update GitHub related functions

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -231,36 +231,6 @@ function download_filename() {
     echo $filename
 }
 
-# Downloads a PHP Source Tarball from GitHub and extracts it to
-# `$TMP/source/$DEFINITION`.
-function download_from_github() {
-    local branch=$1
-    local repo=$2
-    local package_file="$TMP/packages/$branch.tar.gz"
-    local url="https://github.com/$repo/tarball/$branch"
-    local temp_package="$TMP/$branch.tar.gz"
-
-    if [ -d "$TMP/source/$DEFINITION" ]; then
-        log "Removing" "Already downloaded and extracted $url"
-        rm -rf "$TMP/source/$DEFINITION"
-    fi
-
-    log "Downloading" "$url"
-
-    # Remove the temp file if one exists.
-    if [ -f "$temp_package" ]; then
-        rm "$temp_package"
-    fi
-
-    http get "$url" > $temp_package
-    cp "$temp_package" "$TMP/packages"
-    rm "$temp_package"
-
-    mkdir "$TMP/source/$DEFINITION"
-
-    extract_gz "$package_file" "$TMP/source/$DEFINITION"
-}
-
 function extract_gz() {
     tar -x -z --strip-components 1 -f "$1" -C "$2"
 }
@@ -427,23 +397,6 @@ function install_package() {
 
     {
         download $url $archive_type
-        cd "$TMP/source/$DEFINITION"
-        build_package
-        cd - > /dev/null
-    } >&4 2>&1
-}
-
-# ### install_package_from_github
-#
-# Downloads and builds the PHP tarball from the given branch/tag on GitHub.
-# Optionally, repo canbe specified as 2nd argument.
-# Otherwise "php/php-src" is used by default.
-function install_package_from_github() {
-    local branch=$1
-    local repo=${2:-php/php-src}
-
-    {
-        download_from_github "$branch" "$repo"
         cd "$TMP/source/$DEFINITION"
         build_package
         cd - > /dev/null

--- a/share/php-build/plugins.d/github.sh
+++ b/share/php-build/plugins.d/github.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Downloads a PHP Source Tarball from GitHub and extracts it to
+# `${TMP}/source/${DEFINITION}`.
+function download_from_github() {
+    local branch=${1}
+    local repository_name=${2}
+    local package_file="${TMP}/packages/${branch}.tar.gz"
+    local package_url="https://github.com/${repository_name}/tarball/${branch}"
+    local package_temporary="${TMP}/${branch}.tar.gz"
+
+    if [ -d "${TMP}/source/${DEFINITION}" ]; then
+        log "Removing" "Already downloaded and extracted ${package_url}"
+        rm -rf "${TMP}/source/${DEFINITION}"
+    fi
+
+    log "Downloading" "${package_url}"
+
+    # Remove the temp file if one exists.
+    if [ -f "${package_temporary}" ]; then
+        rm "${package_temporary}"
+    fi
+
+    http get "${package_url}" > ${package_temporary}
+    cp "${package_temporary}" "${TMP}/packages"
+    rm "${package_temporary}"
+
+    mkdir "${TMP}/source/${DEFINITION}"
+
+    extract_gz "${package_file}" "${TMP}/source/${DEFINITION}"
+}
+
+# ### clone_from_github
+# Clones a source from GitHub and extracts it to `${TMP}/source/${DEFINITION}`.
+function clone_from_github() {
+    local branch=${1}
+    local repository_name=${2}
+    local repository_url="git://github.com/${repository_name}.git"
+    local directory="${TMP}/source/${DEFINITION}"
+
+    if [ -d "${directory}" ]; then
+        log "Removing" "Already cloned branch ${branch} from ${repository_url}"
+        rm -rf "${directory}"
+    fi
+
+    log "Cloning" "Branch ${branch} from ${repository_url}"
+
+    git clone --branch=${branch} --depth=1 --quiet --recursive ${repository_url} "${directory}" 2>&4
+}
+
+# ### install_package_from_github
+#
+# Clones and builds the PHP tarball from the given branch/tag on GitHub.
+# Optionally, repository canbe specified as 2nd argument.
+# Otherwise "php/php-src" is used by default.
+function install_package_from_github() {
+    local branch=${1}
+    local repository_name=${2:-php/php-src}
+
+    {
+        clone_from_github ${branch} ${repository_name}
+        cd "${TMP}/source/${DEFINITION}"
+        build_package
+        cd - > /dev/null
+    } >&4 2>&1
+}


### PR DESCRIPTION
- Create `clone_from_github` function
- Clones the repository and its submodules instead of download the tarball from GitHub
- Move GitHub related functions to "share/php-build/plugins.d/github.sh"

Closes #289