### PR TITLE
Better sort for definitions

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -271,12 +271,11 @@ function extract_bz2() {
 
 # List all defintions found in `share/php-build/definitions`
 function list_definitions() {
-    {
-        for definition in "$PHP_BUILD_ROOT/share/php-build/definitions/"*
-        do
-            echo $(basename "$definition")
-        done
-    } | sort
+    ls -1 "${PHP_BUILD_ROOT}/share/php-build/definitions/"* |
+        xargs -n1 basename |
+        sed -E 's,([0-9])([a-z]),\1.\2,g; s,\b([0-9])\b,0\1,g;' |
+        sort |
+        sed -E 's,\b0([0-9])\b,\1,g; s,\.([a-z]),\1,g'
 }
 
 function trigger_before_install() {


### PR DESCRIPTION
Displays:
```
 5.6.0
 5.6.1
 5.6.2
 5.6.3
 5.6.4
 5.6.5
 5.6.6
 5.6.7
 5.6.8
 5.6.9
 5.6.10
 5.6.11
 5.6.12
 5.6snapshot
```

Instead of:
```
5.6.0
5.6.1
5.6.10
5.6.11
5.6.12
5.6.2
5.6.3
5.6.4
5.6.5
5.6.6
5.6.7
5.6.8
5.6.9
5.6snapshot
```