### PR TITLE
Improve definitions' sort

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -273,9 +273,9 @@ function extract_bz2() {
 function list_definitions() {
     ls -1 "${PHP_BUILD_ROOT}/share/php-build/definitions/"* |
         xargs -n1 basename |
-        sed -E 's,([0-9])([a-z]),\1.\2,g; s,\b([0-9])\b,0\1,g;' |
+        sed -E 's,([0-9])([a-z]),\1.\2,g; s,\b([0-9])\b,0\1,g;s,$,~,g' |
         sort |
-        sed -E 's,\b0([0-9])\b,\1,g; s,\.([a-z]),\1,g'
+        sed -E 's,~$,,g; s,\b0([0-9])\b,\1,g; s,\.([a-z]),\1,g'
 }
 
 function trigger_before_install() {


### PR DESCRIPTION
With this change the stable versions, like 1.0.0 are displayed after the unstable versions, like 1.0.0beta2, 1.0.0-rc1.

The "~" was chosen because it is one of the lastest chars in the ASCII table.

Example:
```
 7.0.0alpha1
 7.0.0alpha2
 7.0.0beta1
 7.0.0beta2
 7.0.0beta3
 7.0.0
 7.0.1
 7.1.0-rc1
 7.1.0
 7.1.1
```

See https://github.com/php-build/php-build/pull/302#issuecomment-128828066