### PR TITLE
Added 'no' for commenting out Xdebug

### DIFF
--- a/share/php-build/plugins.d/xdebug.sh
+++ b/share/php-build/plugins.d/xdebug.sh
@@ -26,7 +26,7 @@ function xdebug_after_install {
      # Comment out the lines in the xdebug.ini when the env variable
     # is set to something to "no"
     local conf_line_prefix=
-    if [ "$PHP_BUILD_XDEBUG_ENABLE" == "off" ]; then
+    if [ "$PHP_BUILD_XDEBUG_ENABLE" == "off" ] || [ "$PHP_BUILD_XDEBUG_ENABLE" == "no" ]; then
         log "XDebug" "XDebug is commented out in $xdebug_ini. Remove the \";\" to enable it."
         conf_line_prefix=";"
     fi


### PR DESCRIPTION
The documentation specifies that PHP_BUILD_XDEBUG_ENABLE=yes|no, but the current source uses yes|off.
Added 'no' as a valid option.
In order to not break backwards compatibility, it's been added as an additional if check rather than replacing the current "off" check.