### PR TITLE
Add "phpenv update" command

### DIFF
--- a/bin/phpenv-update
+++ b/bin/phpenv-update
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+[ -n "$PHPENV_DEBUG" ] && set -x
+
+if [ -z "$PHPENV_ROOT" ]; then
+  PHPENV_ROOT="${HOME}/.phpenv"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE:-${(%):-%N}}")"; pwd)"
+cd ${script_dir}/..
+git pull

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
+if [ -z "$RBENV_ROOT" ]; then
+  RBENV_ROOT="${HOME}/.phpenv"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE:-${(%):-%N}}")"; pwd)"
+cd ${script_dir}/..
+git pull


### PR DESCRIPTION
This pull request introduces new phpenv sub-command `phpenv update` when php-build is used as phpenv plugin.
The new command executes `git pull` on php-build working directory. 

This command works fine on both `bash` and `zsh`.