### PR TITLE
Add '$PHPBUILD_KEEP_OBJECT_FILES' environment variable not to remove object files in build tree

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -77,6 +77,9 @@ CONFIGURE_OPTIONS=$(cat "$PHP_BUILD_ROOT/share/php-build/default_configure_optio
 # Patches to be applied at the source
 PATCH_FILES=""
 
+# Whether do "make clean" after installation or not
+[ -z "$PHPBUILD_KEEP_OBJECT_FILES" ] && PHPBUILD_KEEP_OBJECT_FILES=off
+
 [ -z "$PHPBUILD_INSTALL_EXTENSION" ] && PHPBUILD_INSTALL_EXTENSION=""
 
 if [ -n "$PHP_BUILD_CONFIGURE_OPTS" ]; then
@@ -323,7 +326,9 @@ function build_package() {
     {
         make
         make install
-        make clean
+        if [ "$PHPBUILD_KEEP_OBJECT_FILES" == "off" ]; then
+            make clean
+        fi
     } > /dev/null
     cd "$cwd"
 


### PR DESCRIPTION
Currently `php-build` always removes all object files after PHP installation.
This pull request provides new build definition function `keep_object_files`, which keeps object file in build tree.
It's useful when attaching a debugger to PHP (debugging PHP itself or some PHP extensions).