### PR TITLE
Implement "--complete" option to uninstall sub-command

### DIFF
--- a/bin/phpenv-uninstall
+++ b/bin/phpenv-uninstall
@@ -13,6 +13,11 @@ set -e
 test -n "${PHPENV_DEBUG}" &&
   set -x
 
+# Provide phpenv completions
+if [ "$1" = "--complete" ]; then
+  exec phpenv-versions --bare
+fi
+
 test -z "${PHPENV_ROOT}" &&
   PHPENV_ROOT="${HOME}/.phpenv"
 

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -13,6 +13,11 @@ set -e
 test -n "${RBENV_DEBUG}" &&
   set -x
 
+# Provide rbenv completions
+if [ "$1" = "--complete" ]; then
+  exec rbenv-versions --bare
+fi
+
 test -z "${RBENV_ROOT}" &&
   RBENV_ROOT="${HOME}/.phpenv"
 


### PR DESCRIPTION
For improving shell operation as follows:

```
$ phpenv uninstall [TAB]
5.3.29          5.5.14          5.6.3           7.0.0RC3        7.0.0RC6        master
(snip)
```