### PR TITLE
Show help message of uninstall sub-command on MacOSX

### DIFF
--- a/bin/phpenv-uninstall
+++ b/bin/phpenv-uninstall
@@ -18,7 +18,7 @@ test -z "${PHPENV_ROOT}" &&
 
 CONFIRM=0
 VERSION=""
-HELP_MESSAGE=$(sed -E 's/^#\s?(.*)/\1/g' "${0}" | sed -nE '/^Usage/,/^Report/p')
+HELP_MESSAGE=$(sed -E 's/^#[[:space:]]?(.*)/\1/g' "${0}" | sed -nE '/^Usage/,/^Report/p')
 
 if [[ "${1}" == '--help' ]] || [[ "${1}" == '-h' ]]; then
   echo "${HELP_MESSAGE}"

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -18,7 +18,7 @@ test -z "${RBENV_ROOT}" &&
 
 CONFIRM=0
 VERSION=""
-HELP_MESSAGE=$(sed -E 's/^#\s?(.*)/\1/g' "${0}" | sed -nE '/^Usage/,/^Report/p')
+HELP_MESSAGE=$(sed -E 's/^#[[:space:]]?(.*)/\1/g' "${0}" | sed -nE '/^Usage/,/^Report/p')
 
 if [[ "${1}" == '--help' ]] || [[ "${1}" == '-h' ]]; then
   echo "${HELP_MESSAGE}"


### PR DESCRIPTION
On MacOSX, `phpenv uninstall --help` shows no messages.

This is because of difference between GNU sed and BSD sed.
The regular expression `\s` works only on GNU sed.
I replaced `\s` to `[[:space:]]`, which is in POSIX regular expression and both sed support this.