### PR TITLE
Fixed incorrect variable expression in rbenv-uninstall

### DIFF
--- a/bin/phpenv-uninstall
+++ b/bin/phpenv-uninstall
@@ -53,7 +53,7 @@ if [[ ${CONFIRM} -eq 0 ]]; then
   echo -n "Are you sure you want to remove version ‘${VERSION}’? [y/N]: "
   read ANSWER
 
-  if [[ "${ANSWER,,}" = "y" ]]; then
+  if [[ "${ANSWER}" = "y" ]]; then
     CONFIRM=1
   fi
 fi

--- a/bin/phpenv-uninstall
+++ b/bin/phpenv-uninstall
@@ -53,7 +53,7 @@ if [[ ${CONFIRM} -eq 0 ]]; then
   echo -n "Are you sure you want to remove version ‘${VERSION}’? [y/N]: "
   read ANSWER
 
-  if [[ "${ANSWER}" = "y" ]]; then
+  if [[ "${ANSWER}" =~ ^[Yy]$ ]]; then
     CONFIRM=1
   fi
 fi

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -53,7 +53,7 @@ if [[ ${CONFIRM} -eq 0 ]]; then
   echo -n "Are you sure you want to remove version ‘${VERSION}’? [y/N]: "
   read ANSWER
 
-  if [[ "${ANSWER,,}" = "y" ]]; then
+  if [[ "${ANSWER}" = "y" ]]; then
     CONFIRM=1
   fi
 fi

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -53,7 +53,7 @@ if [[ ${CONFIRM} -eq 0 ]]; then
   echo -n "Are you sure you want to remove version ‘${VERSION}’? [y/N]: "
   read ANSWER
 
-  if [[ "${ANSWER}" = "y" ]]; then
+  if [[ "${ANSWER}" =~ ^[Yy]$ ]]; then
     CONFIRM=1
   fi
 fi


### PR DESCRIPTION
When I tried `phpenv uninstall`, the following error occurred.

```
$ phpenv uninstall 7.0.0RC2
Are you sure you want to remove version ‘7.0.0RC2’? [y/N]: y
/Users/hnw/.phpenv/plugins/php-build/bin/rbenv-uninstall: line 56: ${ANSWER,,}: bad substitution
$
```

It seems to be typo, so fixed.