### PR TITLE
Removed git-core package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ addons:
  apt:
   packages:
    - php5-cli
-   - git-core
    - libmcrypt-dev
    - libjpeg-dev
    - libreadline-dev


### PR DESCRIPTION
Travis doesn't seem to allow it, and I don't think we need it anyway?