### PR TITLE
Cleaned up packages to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ sudo: false
 addons:
   apt:
     packages:
-      - php5-cli
       - libmcrypt-dev
-      - libjpeg-dev
-      - libreadline-dev
-      - re2c
       - libtidy-dev
+      - php5-cli
+      - re2c
 
 env:
   global:


### PR DESCRIPTION
`libjpeg-dev` and `libreadline-dev` can be removed because they're already installed. I've then just alphabetically sorted the list of dependencies.