### PR TITLE
Backport fix for new libxml

### DIFF
--- a/share/php-build/definitions/5.2.17
+++ b/share/php-build/definitions/5.2.17
@@ -8,6 +8,7 @@ configure_option -R "--with-pdo-mysql"
 patch_file "gmp.c.patch"
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
+patch_file "php-5.4.6-libxml2-2.9.patch"
 
 with_pear
 

--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.10.tar.bz2;h=e81d7ff32deb09b4e514540a181b583e681e3423;hb=483968fd35676f02e2cfbe01108afe2f4510e4ab"
 install_pyrus
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.11.tar.bz2;h=5da1e305b9a2294264610a6d756c38386f3d6397;hb=1be2f72633b0a8ecc1a01fe23acb9253fea71c63"
 install_pyrus
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.12.tar.bz2;h=54792f190cdafe33dd4e2e0100076ad33f9edc6c;hb=7d42906904247fbe3cf1bdb1ec945628fc24af8c"
 install_pyrus
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.13.tar.bz2;h=3ca3e799c3e24eec433669b956ab21763430bc21;hb=fc98a2ea17a9f6fddcc28207ebee4904619e19a2"
 install_pyrus
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.14.tar.bz2;h=36088f2c5dd0cf480030dc7f91ce7efc0026e034;hb=5166081c36f1170c175e1913179a1559434c77a8"
 install_pyrus
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.15.tar.bz2;h=bb661f88f9fdf66973bf88f68e626b7ba0d76c35;hb=9d55e80bd741bc0eefa5c5fb1e4fb7c45f2398f5"
 install_pyrus
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.16.tar.bz2;h=0b4c03fb4c250d4aaa5d7d5bf3a13b0a0b17a185;hb=72ad55a500ace2d6f46c4e88f078bac52f11e99c"
 install_pyrus
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -1,5 +1,6 @@
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
+patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.2.tar.bz2;h=69f6e396a0898af2d528d0826704460327191eee;hb=68deb8a9489af4c64ce4bb50e93db6328ddaf4e9"
 install_pyrus

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -1,5 +1,6 @@
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
+patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.3.tar.bz2;h=c473d92b8399ed7dfc995864d8c0987041300a22;hb=b142c68a1bc6ef1eb24fc61fed1b4bf702b4751f"
 install_pyrus

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -1,4 +1,5 @@
 patch_file "xp_ssl.c.patch"
+patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.6.tar.bz2;h=70fcfecaaa6c58d20a1a8080a7d68e111bb8f9ba;hb=ff4121c1cdebd9248ee7d5726e1abd8c0218cac9"
 install_pyrus

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.8.tar.bz2;h=9740dd93a54ad4216bb43baaefeb8b0bc219861b;hb=bc2bfc2a0c93a8cc8ed5fa56d51f59c2d5615a80"
 install_pyrus
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.9.tar.bz2;h=2a0bceb5f921a74433e318d638d84adcbbf14756;hb=ded0904f93cb86fbb23f5b4d5790c8df500b7bf7"
 install_pyrus
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.4.0
+++ b/share/php-build/definitions/5.4.0
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.0.tar.bz2;h=c6b90d8907d2f695cee4b9ba99e50e5f84ebb24f;hb=108d84532bb7dbc402baa547906f4b8c8b385247"
 install_pyrus
 install_xdebug "2.3.3"

--- a/share/php-build/definitions/5.4.1
+++ b/share/php-build/definitions/5.4.1
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.1.tar.bz2;h=af3337316638a3060016bd1a2484f3967918d7b0;hb=9362c63c2734d4207456c1bf156033006f8f084b"
 install_pyrus
 install_xdebug "2.3.3"

--- a/share/php-build/definitions/5.4.2
+++ b/share/php-build/definitions/5.4.2
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.2.tar.bz2;h=beaf09392b3dbd2a6d1d7b9fe4a1a666b02c3cf8;hb=dc9af806a66c6bcc3b59d15a289a35304a2e3155"
 install_pyrus
 install_xdebug "2.3.3"

--- a/share/php-build/definitions/5.4.3
+++ b/share/php-build/definitions/5.4.3
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.3.tar.bz2;h=94ad3994b566844cbd4ab296b6feec596cb733f5;hb=7f8220645a75deb245db5a1ce8dc53827931ec43"
 install_pyrus
 install_xdebug "2.3.3"

--- a/share/php-build/definitions/5.4.4
+++ b/share/php-build/definitions/5.4.4
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.4.tar.bz2;h=b4b19234b19f5c00345abdd5fc15b4962a25406e;hb=91ccf2ea2f466a5a012cbee00db3eea7b3ed5564"
 install_pyrus
 install_xdebug "2.3.3"

--- a/share/php-build/definitions/5.4.5
+++ b/share/php-build/definitions/5.4.5
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.5.tar.bz2;h=12181dfd61374540375e1d7b77576888ab5548c5;hb=9d55e80bd741bc0eefa5c5fb1e4fb7c45f2398f5"
 install_pyrus
 install_xdebug "2.3.3"

--- a/share/php-build/definitions/5.4.6
+++ b/share/php-build/definitions/5.4.6
@@ -1,3 +1,5 @@
+patch_file "php-5.4.6-libxml2-2.9.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.6.tar.bz2;h=e17d663484714d00244ffd8ab61898017571fc61;hb=c9ee21e0d046f234ee6f17faad475fff65373f95"
 install_pyrus
 install_xdebug "2.3.3"

--- a/share/php-build/patches/php-5.4.6-libxml2-2.9.patch
+++ b/share/php-build/patches/php-5.4.6-libxml2-2.9.patch
@@ -1,0 +1,57 @@
+diff -c -r php-5.4.6-orig/ext/dom/documenttype.c php-5.4.6/ext/dom/documenttype.c
+*** php-5.4.6-orig/ext/dom/documenttype.c	2012-08-15 13:26:05.000000000 +0900
+--- php-5.4.6/ext/dom/documenttype.c	2013-11-05 02:03:54.000000000 +0900
+***************
+*** 205,211 ****
+--- 205,215 ----
+  		if (buff != NULL) {
+  			xmlNodeDumpOutput (buff, NULL, (xmlNodePtr) intsubset, 0, 0, NULL);
+  			xmlOutputBufferFlush(buff);
++ #ifdef LIBXML2_NEW_BUFFER
++ 			ZVAL_STRINGL(*retval, xmlOutputBufferGetContent(buff), xmlOutputBufferGetSize(buff), 1);
++ #else
+  			ZVAL_STRINGL(*retval, buff->buffer->content, buff->buffer->use, 1);
++ #endif
+  			(void)xmlOutputBufferClose(buff);
+  			return SUCCESS;
+  		}
+diff -c -r php-5.4.6-orig/ext/dom/node.c php-5.4.6/ext/dom/node.c
+*** php-5.4.6-orig/ext/dom/node.c	2012-08-15 13:26:05.000000000 +0900
+--- php-5.4.6/ext/dom/node.c	2013-11-05 02:03:54.000000000 +0900
+***************
+*** 1895,1903 ****
+--- 1895,1911 ----
+          RETVAL_FALSE;
+      } else {
+  		if (mode == 0) {
++ #ifdef LIBXML2_NEW_BUFFER
++ 			ret = xmlOutputBufferGetSize(buf);
++ #else
+  			ret = buf->buffer->use;
++ #endif
+  			if (ret > 0) {
++ #ifdef LIBXML2_NEW_BUFFER
++ 				RETVAL_STRINGL((char *) xmlOutputBufferGetContent(buf), ret, 1);
++ #else
+  				RETVAL_STRINGL((char *) buf->buffer->content, ret, 1);
++ #endif
+  			} else {
+  				RETVAL_EMPTY_STRING();
+  			}
+diff -c -r php-5.4.6-orig/ext/simplexml/simplexml.c php-5.4.6/ext/simplexml/simplexml.c
+*** php-5.4.6-orig/ext/simplexml/simplexml.c	2012-08-15 13:26:05.000000000 +0900
+--- php-5.4.6/ext/simplexml/simplexml.c	2013-11-05 02:03:54.000000000 +0900
+***************
+*** 1417,1423 ****
+--- 1417,1427 ----
+  
+  			xmlNodeDumpOutput(outbuf, (xmlDocPtr) sxe->document->ptr, node, 0, 0, ((xmlDocPtr) sxe->document->ptr)->encoding);
+  			xmlOutputBufferFlush(outbuf);
++ #ifdef LIBXML2_NEW_BUFFER
++ 			RETVAL_STRINGL((char *)xmlOutputBufferGetContent(outbuf), xmlOutputBufferGetSize(outbuf), 1);
++ #else
+  			RETVAL_STRINGL((char *)outbuf->buffer->content, outbuf->buffer->use, 1);
++ #endif
+  			xmlOutputBufferClose(outbuf);
+  		}
+  	} else {


### PR DESCRIPTION
In libxml2 2.9.0, a new API was introduced. However, it's not compatible with the previous one. In this effect, the old PHPs can't be compiled with libxml2 2.9.0+.

In PHP 5.3.17/5.4.7, this problem was fixed. This pull request backports the fix to the old PHPs.

This pull request is related to #320, because the stock libxml2 in MacOSX CI environment is 2.9.0.

See also:
- https://mail.gnome.org/archives/xml/2012-August/msg00028.html
- https://github.com/php/php-src/commit/c4b26cc1b0b0521c75e653fffec2a9e3b4bf8cbb


***

### Voting

Member | Vote
-----------|-------
@GrahamCampbell  | :-1: 
@henriquemoody | :+1: 
@rogeriopradoj | :+1: 