### PR TITLE
Show detailed progress on Travis CI

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,7 +40,7 @@ echo
 
 for definition in $BUILD_LIST; do
     echo -n "Building '$definition'..."
-    if ./bin/php-build --pear "$definition" "$BUILD_PREFIX/$definition" &> /dev/null; then
+    if ./bin/php-build --pear "$definition" "$BUILD_PREFIX/$definition"; then
         echo "OK"
 
         export TEST_PREFIX="$BUILD_PREFIX/$definition"


### PR DESCRIPTION
It seems to be inconvenient that the output of `php-build` is currently suppressed on Travis CI, especially when the error is occurred in networking or something not compiling. (See #336)