### PR TITLE
Clean extension repository before git pull

### DIFF
--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -92,6 +92,8 @@ function _checkout_extension {
     if [ -d "$source_dir" ] && [ -d "$source_dir/.git" ]; then
         log "$name" "Updating $name from Git Master"
         cd "$source_dir"
+        git clean -fdx
+        git reset --hard HEAD
         git pull origin master > /dev/null
         cd "$cwd"
     else


### PR DESCRIPTION
For at least memcached, if re-using the same repository to install a second version of PHP from the repository, it will fail to pull, and consequentially fail the build, due to not being able to properly pull the directory. It seems it creates/alters some files that are in source control and it cannot update.