### PR TITLE
Export source_path to before-install scripts

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -256,6 +256,7 @@ function list_definitions() {
 function trigger_before_install() {
     export PHP_BUILD_ROOT
     export PREFIX
+    export SOURCE_PATH="$1"
 
     local triggers_dir="$PHP_BUILD_ROOT/share/php-build/before-install.d/"
     local triggers=$(ls "$triggers_dir")
@@ -318,7 +319,7 @@ function build_package() {
 
     configure_package "$source_path"
 
-    trigger_before_install 2>&4
+    trigger_before_install "$source_path" 2>&4
 
     apply_patches "$source_path" 2>&4
 


### PR DESCRIPTION
I think {before,after}-install.d/ are really good extension points. IMHO it's more useful if we can access to the PHP source tree from before-install scripts. For example, issues such as #204 can be solved easily by users without changing php-build file itself.