### PR TITLE
Remove hard-patch code for APXS handling

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -487,7 +487,7 @@ function with_apxs2() {
     if [ -z "$apxs" ]; then
         apxs="$PHP_BUILD_APXS"
     fi
-    APXS_PATH="$apxs"
+    PHP_BUILD_APXS="$apxs"
 
     configure_option "--with-apxs2" "$apxs"
 }
@@ -566,19 +566,9 @@ $CONFIGURE_OPTIONS"
     ./configure $argv > /dev/null
 
     # Use php-build prefix for the Apache libexec folder
-    cat <<EOF | patch -N -p1 -s || true
-*** 5.2.17-orig/Makefile 2012-11-26 19:10:33.000000000 +0900
---- 5.2.17/Makefile 2012-11-26 19:11:53.000000000 +0900
-***************
-*** 105 ****
-! INSTALL_IT = \$(mkinstalldirs) '\$(INSTALL_ROOT)/usr/libexec/apache2' && \$(mkinstalldirs) '\$(INSTALL_ROOT)/private/etc/apache2' && /usr/sbin/apxs -S LIBEXECDIR='\$(INSTALL_ROOT)/usr/libexec/apache2' -S SYSCONFDIR='\$(INSTALL_ROOT)/private/etc/apache2' -i -a -n php5 libs/libphp5.so
---- 105 ----
-! INSTALL_IT = \$(mkinstalldirs) '$PREFIX/libexec/apache2' && \$(mkinstalldirs) '\$(INSTALL_ROOT)/private/etc/apache2' && /usr/sbin/apxs -S LIBEXECDIR='$PREFIX/libexec/apache2' -S SYSCONFDIR='\$(INSTALL_ROOT)/private/etc/apache2' -i -a -n php5 libs/libphp5.so
-EOF
-
-    if [ -n "$APXS_PATH" ]; then
-        _LIBEXECDIR=`$APXS_PATH -q LIBEXECDIR`
-        sed -i"" -e "s|LIBEXECDIR='\$(INSTALL_ROOT)$_LIBEXECDIR'|LIBEXECDIR=$PREFIX/libexec|" "$source_path/Makefile"
+    if [ -n "$PHP_BUILD_APXS" ]; then
+        apxs_libexecdir=$($PHP_BUILD_APXS -q LIBEXECDIR)
+        sed -i"" -e "s|'\$(INSTALL_ROOT)${apxs_libexecdir}'|${PREFIX}${apxs_libexecdir}|g" ${source_path}/Makefile
     fi
 
     cd "$backup_pwd"

--- a/bin/php-build
+++ b/bin/php-build
@@ -487,6 +487,7 @@ function with_apxs2() {
     if [ -z "$apxs" ]; then
         apxs="$PHP_BUILD_APXS"
     fi
+    APXS_PATH="$apxs"
 
     configure_option "--with-apxs2" "$apxs"
 }
@@ -574,6 +575,11 @@ $CONFIGURE_OPTIONS"
 --- 105 ----
 ! INSTALL_IT = \$(mkinstalldirs) '$PREFIX/libexec/apache2' && \$(mkinstalldirs) '\$(INSTALL_ROOT)/private/etc/apache2' && /usr/sbin/apxs -S LIBEXECDIR='$PREFIX/libexec/apache2' -S SYSCONFDIR='\$(INSTALL_ROOT)/private/etc/apache2' -i -a -n php5 libs/libphp5.so
 EOF
+
+    if [ -n "$APXS_PATH" ]; then
+        _LIBEXECDIR=`$APXS_PATH -q LIBEXECDIR`
+        sed -i"" -e "s|LIBEXECDIR='\$(INSTALL_ROOT)$_LIBEXECDIR'|LIBEXECDIR=$PREFIX/libexec|" "$source_path/Makefile"
+    fi
 
     cd "$backup_pwd"
 }


### PR DESCRIPTION
Improves upon #204.

No longer any need for the manual patching of the Makefile as it can be done with sed and no longer applies to PHP7 (which always causes a Makefile.rej file to be created.)
This patch will put both the apache mod_php module in the phpenv folder rather than attempting to write it directly into the Apache folder, which may require root permission and is better to be managed separately for each PHP install.