### PR TITLE
Unify naming for _checkout_extension revision

### DIFF
--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -81,7 +81,7 @@ function _download_extension {
 
 function _checkout_extension {
     local name=$1
-    local version="$2"
+    local revision="$2"
     local url_source="$3"
     local source_cwd="$4"
     local configure_args="$5"
@@ -101,8 +101,8 @@ function _checkout_extension {
         git clone "$url_source" "$source_dir" > /dev/null
     fi
 
-    if [ -n "$version" ]; then
-        log "$name" "Checkout specified revision: $version"
+    if [ -n "$revision" ]; then
+        log "$name" "Checkout specified revision: $revision"
         cd "$source_dir"
         git reset --hard $revision
         cd "$cwd"


### PR DESCRIPTION
Currently requesting a specific commit fails to work correctly as the variable ```$revision``` is unset. It will always checkout HEAD from master.
Use ```$revision``` instead of ```$version``` for checking out an extension from source.