### PR TITLE
Made -r a fallback if -E is not found for sed

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -245,11 +245,19 @@ function extract_bz2() {
 
 # List all defintions found in $PHP_BUILD_DEFINITION_PATH
 function list_definitions() {
+    local sed_regex_switch='E'
+   
+    # sed switch -E is BSD specific and only added to UNIX sed after v4.2
+    # fallback to -r if -E does not work
+    if ! sed -${sed_regex_switch} '' /dev/null > /dev/null 2>&1; then
+        sed_regex_switch='r'
+    fi
+
     ls -1 "${PHP_BUILD_DEFINITION_PATH}/"* |
         xargs -n1 basename |
-        sed -E 's,([0-9])([a-z]),\1.\2,g; s,\b([0-9])\b,0\1,g;s,$,~,g' |
+        sed -${sed_regex_switch} 's,([0-9])([a-z]),\1.\2,g; s,\b([0-9])\b,0\1,g;s,$,~,g' |
         sort |
-        sed -E 's,~$,,g; s,\b0([0-9])\b,\1,g; s,\.([a-z]),\1,g'
+        sed -${sed_regex_switch} 's,~$,,g; s,\b0([0-9])\b,\1,g; s,\.([a-z]),\1,g'
 }
 
 function trigger_before_install() {

--- a/bin/phpenv-uninstall
+++ b/bin/phpenv-uninstall
@@ -21,9 +21,17 @@ fi
 test -z "${PHPENV_ROOT}" &&
   PHPENV_ROOT="${HOME}/.phpenv"
 
+SED_REGEX_SWITCH='e'
+
+# sed switch -E is BSD specific and only added to UNIX sed after v4.2
+# fallback to -r if -E does not work
+if ! sed -$SED_REGEX_SWITCH '' /dev/null > /dev/null 2>&1; then
+  SED_REGEX_SWITCH='r'
+fi
+
 CONFIRM=0
 VERSION=""
-HELP_MESSAGE=$(sed -E 's/^#[[:space:]]?(.*)/\1/g' "${0}" | sed -nE '/^Usage/,/^Report/p')
+HELP_MESSAGE=$(sed -${SED_REGEX_SWITCH} 's/^#[[:space:]]?(.*)/\1/g' "${0}" | sed -n${SED_REGEX_SWITCH} '/^Usage/,/^Report/p')
 
 if [[ "${1}" == '--help' ]] || [[ "${1}" == '-h' ]]; then
   echo "${HELP_MESSAGE}"

--- a/bin/phpenv-uninstall
+++ b/bin/phpenv-uninstall
@@ -21,7 +21,7 @@ fi
 test -z "${PHPENV_ROOT}" &&
   PHPENV_ROOT="${HOME}/.phpenv"
 
-SED_REGEX_SWITCH='e'
+SED_REGEX_SWITCH='E'
 
 # sed switch -E is BSD specific and only added to UNIX sed after v4.2
 # fallback to -r if -E does not work

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -21,9 +21,17 @@ fi
 test -z "${RBENV_ROOT}" &&
   RBENV_ROOT="${HOME}/.phpenv"
 
+SED_REGEX_SWITCH='E'
+
+# sed switch -E is BSD specific and only added to UNIX sed after v4.2
+# fallback to -r if -E does not work
+if ! sed -$SED_REGEX_SWITCH '' /dev/null > /dev/null 2>&1; then
+  SED_REGEX_SWITCH='r'
+fi
+
 CONFIRM=0
 VERSION=""
-HELP_MESSAGE=$(sed -E 's/^#[[:space:]]?(.*)/\1/g' "${0}" | sed -nE '/^Usage/,/^Report/p')
+HELP_MESSAGE=$(sed -${SED_REGEX_SWITCH} 's/^#[[:space:]]?(.*)/\1/g' "${0}" | sed -n${SED_REGEX_SWITCH} '/^Usage/,/^Report/p')
 
 if [[ "${1}" == '--help' ]] || [[ "${1}" == '-h' ]]; then
   echo "${HELP_MESSAGE}"

--- a/make-release.sh
+++ b/make-release.sh
@@ -9,6 +9,14 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+SED_REGEX_SWITCH='E'
+
+# sed switch -E is BSD specific and only added to UNIX sed after v4.2
+# fallback to -r if -E does not work
+if ! sed -$SED_REGEX_SWITCH '' /dev/null > /dev/null 2>&1; then
+    SED_REGEX_SWITCH='r'
+fi
+
 echo "Releasing $VERSION"
 echo "==="
 echo
@@ -29,7 +37,7 @@ echo "Done"
 
 echo
 echo "---> Updating version number to \"$VERSION\"... "
-sed -E -e "s/(PHP_BUILD_VERSION=\")(.+)(\")/\1$VERSION\3/" -i '' bin/php-build
+sed -${SED_REGEX_SWITCH} -e "s/(PHP_BUILD_VERSION=\")(.+)(\")/\1$VERSION\3/" -i '' bin/php-build
 ./bin/php-build --version
 echo "Done"
 


### PR DESCRIPTION
The ```-E``` switch is not supported in some older versions of sed.