### PR TITLE
add and fix usage details for phpenv

### DIFF
--- a/bin/phpenv-install
+++ b/bin/phpenv-install
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+#
+# Summary: Install a PHP version using the php-build plugin
+#
+# Usage: phpenv install [--ini|-i <environment>] <version>
+#        phpenv install [--ini|-i <environment>] <definition-file>
+#
+# For detailed information on installing PHP versions with
+# php-build, including a list of environment variables for adjusting
+# compilation, see: https://github.com/php-build/php-build
+#
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
 

--- a/bin/phpenv-uninstall
+++ b/bin/phpenv-uninstall
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# Usage: phpenv uninstall [--force|-f] VERSION
-# Remove an installed PHP version.
+#
+# Summary: Uninstall a specific PHP version using the php-build plugin
+#
+# Usage: phpenv uninstall [-f|--force] <version>
 #
 #   -f, --force   Force removal, never prompt
 #   -h, --help    Displays this help
 #
+# See `phpenv versions` for a complete list of installed versions.
 # Report bugs on https://github.com/php-build/php-build.
 #
-
 set -e
 
 test -n "${PHPENV_DEBUG}" &&


### PR DESCRIPTION
`phpenv help` use Summary and Usage on CommentOuts.

So, I add and fix comments for phpenv on this request.

## Test Result

```bash
$ ./run-tests.sh 5.6.9
Testing definitions 5.6.9

Building '5.6.9'...[Info]: Loaded extension plugin
[Info]: Loaded apc Plugin.
[Info]: Loaded composer Plugin.
[Info]: Loaded github Plugin.
[Info]: Loaded uprofiler Plugin.
[Info]: Loaded xdebug Plugin.
[Info]: Loaded xhprof Plugin.
[Info]: php.ini-production gets used as php.ini
[Info]: Building 5.6.9 into /tmp/php-build-test-20160323010250/5.6.9
[Skipping]: Already downloaded and extracted https://secure.php.net/distributions/php-5.6.9.tar.bz2
[Preparing]: /var/tmp/php-build/source/5.6.9
[Compiling]: /var/tmp/php-build/source/5.6.9
[xdebug]: Installing version 2.3.3
[xdebug]: Compiling xdebug in /var/tmp/php-build/source/xdebug-2.3.3
[xdebug]: Installing xdebug configuration in /tmp/php-build-test-20160323010250/5.6.9/etc/conf.d/xdebug.ini
[xdebug]: Cleaning up.
[Info]: Enabling Opcache...
[Info]: Done
[Info]: The Log File is not empty, but the Build did not fail. Maybe just warnings got logged. You can review the log in /tmp/php-build.5.6.9.20160323010250.log
[Success]: Built 5.6.9 successfully.
OK
Running Tests...
 ✓ Patches are applied
 ✓ Installs xdebug.so
 ✓ Enables XDebug

3 tests, 0 failures
```