### PR TITLE
Added zendopcache extension 

### DIFF
--- a/share/php-build/extension/definition
+++ b/share/php-build/extension/definition
@@ -9,3 +9,4 @@
 "xcache","http://xcache.lighttpd.net/pub/Releases/$version/xcache-$version.tar.gz",,,"--enable-xcache","extension",
 "xdebug","http://xdebug.org/files/xdebug-$version.tgz","git://github.com/xdebug/xdebug.git",,"--enable-xdebug","zend_extension","xdebug_after_install"
 "xhprof","http://pecl.php.net/get/xhprof-$version.tgz","git://github.com/facebook/xhprof.git",,,"extension","xhprof_after_install"
+"zendopcache","http://pecl.php.net/get/zendopcache-$version.tgz","https://github.com/zendtech/ZendOptimizerPlus.git",,"--enable-opcache","zend_extension","zendopcache_after_install"

--- a/share/php-build/plugins.d/zendopcache.sh
+++ b/share/php-build/plugins.d/zendopcache.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# This shell scriplet is meant to be included by other shell scripts
+# to set up some variables and a few helper shell functions.
+
+function install_zendopcache_master {
+    install_extension_source "zendopcache" "$1"
+}
+
+function install_zendopcache {
+    install_extension "zendopcache" "$1"
+}
+
+function zendopcache_after_install {
+    local source_dir=$1
+    local ini_file=$2
+    local extension_type=$3
+    local extension_dir=$4
+
+    # While the extension name is ZendOpcache, its extension is named "opcache.so"
+    # We need to reflect this in the configuration
+    echo "$extension_type=\"$extension_dir/opcache.so\"" > $ini_file
+}


### PR DESCRIPTION
Before PHP 5.5, Zend Opcache was an optional cache module. To make it a little easier to install, add it to the extension's definition list so that it can be compiled and enabled with PHP during initial install.
