### PR TITLE
GIT ignore /versions directory to allow builds to be generated inside it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .vagrant
 tmp/
 var/
+/versions/
 
 share/php-build/before-install.d/*
 !share/php-build/before-install.d/.empty


### PR DESCRIPTION
I like to put my builds inside this directory. This is personal preference so I'm ok if there's any issues with adding it. It will save me having to maintain a fork.