### PR TITLE
Upgrade Mac OS X version to El Capitan / Xcode to 8  on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+osx_image: xcode8
 
 os:
   - linux
@@ -31,8 +32,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install re2c; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libmcrypt; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bison27 && brew link bison27 --force; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DEFINITION" =~ ^"7.1.".*$ ]]; then brew install openssl && export PHP_BUILD_CONFIGURE_OPTS="--with-openssl=$(brew --prefix openssl)" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl libxml2 && export PHP_BUILD_CONFIGURE_OPTS="--with-openssl=$(brew --prefix openssl) --with-libxml-dir=$(brew --prefix libxml2)"; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DEFINITION" == "5.2.17" ]]; then brew install mysql ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DEFINITION" == "5.3.3" ]]; then brew install libevent ; fi
 


### PR DESCRIPTION
Default Mac OS X environment on Travis CI is OS X 10.9 (Mavericks) + Xcode 6.1 (see: https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version ). 

And now, Homebrew no longer supports Mavericks.

```
$ brew install mysql
Warning: You are using macOS 10.9.
We (and Apple) do not provide support for this old version.
You may encounter build failures or other breakages.
Please create pull-requests instead of filing issues.
(snip)
```

So, we should upgrade Mac OS X version on Travis CI. This PR introduces OS X 10.11 (El Capitan) + Xcode 8 environment.

Also removed the package `bison27`,  it seems to be unused.