### PR TITLE
Enable phpdbg by default for PHP 5.6.x

### DIFF
--- a/share/php-build/default_configure_options
+++ b/share/php-build/default_configure_options
@@ -31,3 +31,4 @@
 --disable-debug
 --enable-fpm
 --enable-bcmath
+--enable-phpdbg


### PR DESCRIPTION
From PHP 5.6.0 phpdbg is included with PHP. However, it is disabled by default for PHP 5.6.x.
It's very useful tool, so I propose to enable phpdbg for PHP 5.6.x.