### PR TITLE
Force link Homebrew's openssl & libxml2 on MacOSX 10.11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install re2c; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libmcrypt; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl libxml2 && export PHP_BUILD_CONFIGURE_OPTS="--with-openssl=$(brew --prefix openssl) --with-libxml-dir=$(brew --prefix libxml2)"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl libxml2; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DEFINITION" == "5.2.17" ]]; then brew install mysql ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DEFINITION" == "5.3.3" ]]; then brew install libevent ; fi
 

--- a/bin/php-build
+++ b/bin/php-build
@@ -83,18 +83,12 @@ PATCH_FILES=""
 
 [ -z "$PHP_BUILD_INSTALL_EXTENSION" ] && PHP_BUILD_INSTALL_EXTENSION=""
 
-if [ -n "$PHP_BUILD_CONFIGURE_OPTS" ]; then
-    CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $PHP_BUILD_CONFIGURE_OPTS"
-fi
+[ -z "$PHP_BUILD_CONFIGURE_OPTS" ] && PHP_BUILD_CONFIGURE_OPTS=""
 
-if [ -n "$CONFIGURE_OPTS" ]; then
-    CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $CONFIGURE_OPTS"
-fi
+[ -z "$CONFIGURE_OPTS" ] && CONFIGURE_OPTS=""
 
 # Enable Zend Thread Safety by setting this value to "yes"
-if [ -z "$PHP_BUILD_ZTS_ENABLE" ]; then
-    PHP_BUILD_ZTS_ENABLE=off
-fi
+[ -z "$PHP_BUILD_ZTS_ENABLE" ] && PHP_BUILD_ZTS_ENABLE=off
 
 PHP_BUILD_VERSION="0.11.0dev"
 
@@ -183,6 +177,25 @@ function is_osx {
     else
         return 1
     fi
+}
+
+function osx_major {
+    if is_osx ; then
+        local osxVersionString=$(sw_vers -productVersion)
+        local osx_major=${osxVersionString%%.*}
+        echo $osx_major
+    fi
+    return 0
+}
+
+function osx_minor {
+    if is_osx ; then
+        local osxVersionString=$(sw_vers -productVersion)
+        local tmp=${osxVersionString#*.}
+        local osx_minor=${tmp%%.*}
+        echo $osx_minor
+    fi
+    return 0
 }
 
 # Downloads a PHP Source Tarball and extracts it to `$TMP/source/$DEFINITION`
@@ -533,6 +546,15 @@ function configure_package() {
         configure_option "--enable-maintainer-zts"
         log "Warning" "Enabling Zend Thread Safety is meant only for maintainers!"
     fi
+
+    # Override `--with-openssl` and `--with-libxml-dir`
+    # if Homebrew's openssl and libxml2 exist on Mac OS X 10.11+.
+    if is_osx && [ "$(osx_major)" -eq 10 ] && [ "$(osx_minor)" -ge 11 ] && [ -n "$(which brew)" ] && [ -e "$(brew --prefix openssl)" ] && [ -e "$(brew --prefix libxml2)" ]; then
+        configure_option -R "--with-openssl" "$(brew --prefix openssl)"
+        configure_option -R "--with-libxml-dir" "$(brew --prefix libxml2)"
+    fi
+
+    CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $PHP_BUILD_CONFIGURE_OPTS $CONFIGURE_OPTS"
 
     # Add the config-file-path, config-file-scan-dir aswell as the
     # prefix to the build options, these cannot be changed by definitions.


### PR DESCRIPTION
If you run `php-build` without options on MacOSX 10.11+, the build will fail like this:

```
/var/tmp/php-build/source/7.0.6/ext/openssl/openssl.c:44:10: fatal error: 'openssl/evp.h' file not found
#include <openssl/evp.h>
         ^
1 error generated.
make: *** [ext/openssl/openssl.lo] Error 1
```

See also: http://qiita.com/hnw/items/62380e713d318906f0cd (In Japanese)

The problem is caused by the fact that libssl on MacOSX 10.11+ consists only of library files without header files.

As discussed in the above URL, it is possible to build correctly by specifing `PHP_BUILD_CONFIGURE_OPTIONS=...` . However I think that it is better to fix php-build.

So I fixed php-build to override `--with-openssl` and `--with-libxml-dir` in configure options only when Homebrew's openssl and libxml2 exist.

The evaluation timing of `PHP_BUILD_CONFIGURE_OPTIONS` was also fixed. This is to make it possible to disable openssl extension by setting `PHP_BUILD_CONFIGURE_OPTIONS=--without-openssl` .
