### PR TITLE
Removed with-mysql from defaults

### DIFF
--- a/share/php-build/default_configure_options
+++ b/share/php-build/default_configure_options
@@ -22,7 +22,6 @@
 --enable-sysvsem
 --enable-sysvshm
 --enable-shmop
---with-mysql=mysqlnd
 --with-mysqli=mysqlnd
 --with-pdo-mysql=mysqlnd
 --with-pdo-sqlite

--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.10.tar.bz2;h=e81d7ff32deb09b4e514540a181b583e681e3423;hb=483968fd35676f02e2cfbe01108afe2f4510e4ab"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.11.tar.bz2;h=5da1e305b9a2294264610a6d756c38386f3d6397;hb=1be2f72633b0a8ecc1a01fe23acb9253fea71c63"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.12.tar.bz2;h=54792f190cdafe33dd4e2e0100076ad33f9edc6c;hb=7d42906904247fbe3cf1bdb1ec945628fc24af8c"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.13.tar.bz2;h=3ca3e799c3e24eec433669b956ab21763430bc21;hb=fc98a2ea17a9f6fddcc28207ebee4904619e19a2"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.14.tar.bz2;h=36088f2c5dd0cf480030dc7f91ce7efc0026e034;hb=5166081c36f1170c175e1913179a1559434c77a8"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.15.tar.bz2;h=bb661f88f9fdf66973bf88f68e626b7ba0d76c35;hb=9d55e80bd741bc0eefa5c5fb1e4fb7c45f2398f5"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.16.tar.bz2;h=0b4c03fb4c250d4aaa5d7d5bf3a13b0a0b17a185;hb=72ad55a500ace2d6f46c4e88f078bac52f11e99c"

--- a/share/php-build/definitions/5.3.17
+++ b/share/php-build/definitions/5.3.17
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.17.tar.bz2;h=5b8477ff1e267359d2b3f1b6d0ae8ae3672af89d;hb=6e47872b79b12476db045f97882ed55480bcd021"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.18
+++ b/share/php-build/definitions/5.3.18
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.18.tar.bz2;h=0453a3ccc7ed29923e2c96d067127d108b4975d6;hb=0251f33df31f77f31c23822772980ca35f3d56a0"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.19
+++ b/share/php-build/definitions/5.3.19
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.19.tar.bz2;h=666ec3f90a28467f97e956589e38c3598918af32;hb=186d0ee2e8600ca14691d7a6bd5833dd6d01542c"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.20
+++ b/share/php-build/definitions/5.3.20
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.20.tar.bz2;h=87a7017b1bc5bcb85ba193486073bf9bf2091b23;hb=ff93ccb17ec622df93c785eb6b579330b9dc6693"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.21
+++ b/share/php-build/definitions/5.3.21
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.21.tar.bz2;h=0d1190369147893601eb50350c5351b8af15b5eb;hb=79e859d6ef335aca213dfced182ea790f6d89090"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.22
+++ b/share/php-build/definitions/5.3.22
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.22.tar.bz2;h=eb6fc208fac9da05251ab891a704bae3cb6acec4;hb=31b7806f2afaf85e7caa9e73491d1c842500543a"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.23
+++ b/share/php-build/definitions/5.3.23
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.23.tar.bz2;h=d82389aa0bbdd72a78333c55d8ec6537ca9eba17;hb=8df98dc7857d7576a2540c5b2fb952b4a8cea4b5"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.24
+++ b/share/php-build/definitions/5.3.24
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.24.tar.bz2;h=42f459aeb6914b192fb589e6251338d8e39d0264;hb=3dd2f12609fc8a730d7cf341a932f6c7b241f03c"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.25
+++ b/share/php-build/definitions/5.3.25
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.25.tar.bz2;h=3f7d55b74ae3bd32a8556f72bc3f66f3d0193a94;hb=456ff125bac581ad3c0a464a7944393f85079101"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.26
+++ b/share/php-build/definitions/5.3.26
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.26.tar.bz2;h=365d98c941570776c7db266ed07784d7060e03b9;hb=a6730f389cd3a53bc640f874a754f8f79c7c3089"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.27
+++ b/share/php-build/definitions/5.3.27
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.3.27.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.28
+++ b/share/php-build/definitions/5.3.28
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.3.28.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.29
+++ b/share/php-build/definitions/5.3.29
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.3.29.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "xp_ssl.c.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.8.tar.bz2;h=9740dd93a54ad4216bb43baaefeb8b0bc219861b;hb=bc2bfc2a0c93a8cc8ed5fa56d51f59c2d5615a80"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.9.tar.bz2;h=2a0bceb5f921a74433e318d638d84adcbbf14756;hb=ded0904f93cb86fbb23f5b4d5790c8df500b7bf7"

--- a/share/php-build/definitions/5.4.0
+++ b/share/php-build/definitions/5.4.0
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.0.tar.bz2;h=c6b90d8907d2f695cee4b9ba99e50e5f84ebb24f;hb=108d84532bb7dbc402baa547906f4b8c8b385247"

--- a/share/php-build/definitions/5.4.1
+++ b/share/php-build/definitions/5.4.1
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.1.tar.bz2;h=af3337316638a3060016bd1a2484f3967918d7b0;hb=9362c63c2734d4207456c1bf156033006f8f084b"

--- a/share/php-build/definitions/5.4.10
+++ b/share/php-build/definitions/5.4.10
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.10.tar.bz2;h=4dbf54e08ee2fb77028aeefb5b03ee0713856a6c;hb=ee8236662d9af60e8f6c32212531bc16bb175266"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.11
+++ b/share/php-build/definitions/5.4.11
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.11.tar.bz2;h=f1218b7345d8724b03061db374dccf8b3ff316e4;hb=e674fe7c2e0ba52772a723047a5b5ffc8db3bfb7"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.12
+++ b/share/php-build/definitions/5.4.12
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.12.tar.bz2;h=36a855340fa72973a958d03827fa07a5b75cceed;hb=eb78a1bdd2dcdc1450420b592fb7c60a93bcb5b9"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.13
+++ b/share/php-build/definitions/5.4.13
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.13.tar.bz2;h=9fc012a888bc2cf7b5fb26e11eef4359c40b269f;hb=301a6d54e0efa1f0cf7b310b49ec03e17adca054"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.14
+++ b/share/php-build/definitions/5.4.14
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.14.tar.bz2;h=0d950f179d586bb1d0e879e0d4aa3a5140e8d5f5;hb=3dd2f12609fc8a730d7cf341a932f6c7b241f03c"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.15
+++ b/share/php-build/definitions/5.4.15
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.15.tar.bz2;h=a7ca6ec5c1792783158c2771f03f65c2c7312053;hb=34663c8d81e0619e23500c3d1a5c7f0d0a49905d"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.16
+++ b/share/php-build/definitions/5.4.16
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.16.tar.bz2;h=855667f60cbb30f5d28ac6aed587c3da2f587f93;hb=b3d820892c8fe64be8026c239d625536a19f7372"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.17
+++ b/share/php-build/definitions/5.4.17
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.17.tar.bz2;h=faa5b8ed7b6e154520fa09627c66b6404ca2f1be;hb=d052c0971b18b6d22b661a914a79be2da93327b5"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.18
+++ b/share/php-build/definitions/5.4.18
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.18.tar.bz2;h=17faefb906ae19191b6336135751331bee83098a;hb=512fc5d1b8622bdda0e41314b8e81d5133854caa"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.19
+++ b/share/php-build/definitions/5.4.19
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.19.tar.bz2;h=dc2babeb364e4767a1320546fced1386b867021d;hb=4c39e3c8edc074dc80077a00eab518be309a858d"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.2
+++ b/share/php-build/definitions/5.4.2
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.2.tar.bz2;h=beaf09392b3dbd2a6d1d7b9fe4a1a666b02c3cf8;hb=dc9af806a66c6bcc3b59d15a289a35304a2e3155"

--- a/share/php-build/definitions/5.4.20
+++ b/share/php-build/definitions/5.4.20
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.20.tar.bz2;h=df5951b5a74997cacae7bdc205cc7f9f69c9c7ce;hb=0d30c35745d0f3ad7a4bc26f84bbcc2d1782f678"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.21
+++ b/share/php-build/definitions/5.4.21
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.21.tar.bz2;h=88f5bafb4f818ffbd9bba9d3cc835b391234ad51;hb=11e7eb77df43a899546be034a66c5679b2e0c939"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.22
+++ b/share/php-build/definitions/5.4.22
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.22.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.23
+++ b/share/php-build/definitions/5.4.23
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.23.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.24
+++ b/share/php-build/definitions/5.4.24
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.24.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.25
+++ b/share/php-build/definitions/5.4.25
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.25.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.26
+++ b/share/php-build/definitions/5.4.26
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.26.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.27
+++ b/share/php-build/definitions/5.4.27
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.27.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.28
+++ b/share/php-build/definitions/5.4.28
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.28.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.29
+++ b/share/php-build/definitions/5.4.29
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.29.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.3
+++ b/share/php-build/definitions/5.4.3
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.3.tar.bz2;h=94ad3994b566844cbd4ab296b6feec596cb733f5;hb=7f8220645a75deb245db5a1ce8dc53827931ec43"

--- a/share/php-build/definitions/5.4.30
+++ b/share/php-build/definitions/5.4.30
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.30.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.31
+++ b/share/php-build/definitions/5.4.31
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.31.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.32
+++ b/share/php-build/definitions/5.4.32
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.32.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.33
+++ b/share/php-build/definitions/5.4.33
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.33.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.34
+++ b/share/php-build/definitions/5.4.34
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.34.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.35
+++ b/share/php-build/definitions/5.4.35
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.35.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.36
+++ b/share/php-build/definitions/5.4.36
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.36.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.37
+++ b/share/php-build/definitions/5.4.37
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.37.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.38
+++ b/share/php-build/definitions/5.4.38
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.38.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.39
+++ b/share/php-build/definitions/5.4.39
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.39.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.4
+++ b/share/php-build/definitions/5.4.4
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.4.tar.bz2;h=b4b19234b19f5c00345abdd5fc15b4962a25406e;hb=91ccf2ea2f466a5a012cbee00db3eea7b3ed5564"

--- a/share/php-build/definitions/5.4.40
+++ b/share/php-build/definitions/5.4.40
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.40.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.41
+++ b/share/php-build/definitions/5.4.41
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.41.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.42
+++ b/share/php-build/definitions/5.4.42
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.42.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.43
+++ b/share/php-build/definitions/5.4.43
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.43.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.44
+++ b/share/php-build/definitions/5.4.44
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.44.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.45
+++ b/share/php-build/definitions/5.4.45
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.4.45.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.5
+++ b/share/php-build/definitions/5.4.5
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.5.tar.bz2;h=12181dfd61374540375e1d7b77576888ab5548c5;hb=9d55e80bd741bc0eefa5c5fb1e4fb7c45f2398f5"

--- a/share/php-build/definitions/5.4.6
+++ b/share/php-build/definitions/5.4.6
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.6.tar.bz2;h=e17d663484714d00244ffd8ab61898017571fc61;hb=c9ee21e0d046f234ee6f17faad475fff65373f95"

--- a/share/php-build/definitions/5.4.7
+++ b/share/php-build/definitions/5.4.7
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.7.tar.bz2;h=718133ae425fa4236c6c17536959c07f18a1ee45;hb=5dde46e9635c40cb0515118a2e46ee015b14984e"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.8
+++ b/share/php-build/definitions/5.4.8
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.8.tar.bz2;h=336267f83d03428851e58477bccf1478211dcbe1;hb=64f1ac741d14dc9a1dbfbe9416619537a7cd2fba"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.9
+++ b/share/php-build/definitions/5.4.9
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.9.tar.bz2;h=452c44736d8391f5e1c89fab62ad47d553f40f4d;hb=685e095dd2b8443b8031a8d5628eabc556a89e1d"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4snapshot
+++ b/share/php-build/definitions/5.4snapshot
@@ -1,2 +1,4 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package_from_github PHP-5.4
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.5.0
+++ b/share/php-build/definitions/5.5.0
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.0.tar.bz2;h=a9d7b5dbc92f9ff99fcaf911047d8c7d465160cf;hb=01253f21cc75bf10e8698d0be9a904ee4f020a99"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.1
+++ b/share/php-build/definitions/5.5.1
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.1.tar.bz2;h=7bf5067be413ff11127904468a7c308152916a80;hb=703b7b0367bb661e9d5ce2ec6f1e9f57f3418b84"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.10
+++ b/share/php-build/definitions/5.5.10
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.10.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.11
+++ b/share/php-build/definitions/5.5.11
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.11.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.12
+++ b/share/php-build/definitions/5.5.12
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.12.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.13
+++ b/share/php-build/definitions/5.5.13
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.13.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.14
+++ b/share/php-build/definitions/5.5.14
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.14.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.15
+++ b/share/php-build/definitions/5.5.15
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.15.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.16
+++ b/share/php-build/definitions/5.5.16
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.16.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.17
+++ b/share/php-build/definitions/5.5.17
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.17.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.18
+++ b/share/php-build/definitions/5.5.18
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.18.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.19
+++ b/share/php-build/definitions/5.5.19
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.19.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.2
+++ b/share/php-build/definitions/5.5.2
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.2.tar.bz2;h=ef23e90fcdc65ec8bfe2c3100780ceaf62951dde;hb=cb66297df342fd7e2e11d4c952d0793e971a3886"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.20
+++ b/share/php-build/definitions/5.5.20
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.20.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.21
+++ b/share/php-build/definitions/5.5.21
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.21.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.22
+++ b/share/php-build/definitions/5.5.22
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.22.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.23
+++ b/share/php-build/definitions/5.5.23
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.23.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.24
+++ b/share/php-build/definitions/5.5.24
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.24.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.25
+++ b/share/php-build/definitions/5.5.25
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.25.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.26
+++ b/share/php-build/definitions/5.5.26
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.26.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.27
+++ b/share/php-build/definitions/5.5.27
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.27.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.28
+++ b/share/php-build/definitions/5.5.28
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.28.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.29
+++ b/share/php-build/definitions/5.5.29
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.29.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.3
+++ b/share/php-build/definitions/5.5.3
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.3.tar.bz2;h=2f8f088ff89cb77873798a58027dcf68271f4cda;hb=4c39e3c8edc074dc80077a00eab518be309a858d"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.30
+++ b/share/php-build/definitions/5.5.30
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.30.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.31
+++ b/share/php-build/definitions/5.5.31
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.31.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.32
+++ b/share/php-build/definitions/5.5.32
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.32.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.33
+++ b/share/php-build/definitions/5.5.33
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.33.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.34
+++ b/share/php-build/definitions/5.5.34
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.34.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.35
+++ b/share/php-build/definitions/5.5.35
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.35.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.36
+++ b/share/php-build/definitions/5.5.36
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.36.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.37
+++ b/share/php-build/definitions/5.5.37
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.37.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.38
+++ b/share/php-build/definitions/5.5.38
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.38.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.4
+++ b/share/php-build/definitions/5.5.4
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.4.tar.bz2;h=6f258d1d91f812f7d7d717dba75e086b796381fd;hb=d57019e4b0bfcaa4d37288c7c7e346ed50ae04a1"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.5
+++ b/share/php-build/definitions/5.5.5
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.5.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.6
+++ b/share/php-build/definitions/5.5.6
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.6.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.7
+++ b/share/php-build/definitions/5.5.7
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.7.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.8
+++ b/share/php-build/definitions/5.5.8
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.8.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.9
+++ b/share/php-build/definitions/5.5.9
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.5.9.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5snapshot
+++ b/share/php-build/definitions/5.5snapshot
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package_from_github PHP-5.5
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.0
+++ b/share/php-build/definitions/5.6.0
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.0.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.1
+++ b/share/php-build/definitions/5.6.1
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.1.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.10
+++ b/share/php-build/definitions/5.6.10
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.10.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.11
+++ b/share/php-build/definitions/5.6.11
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.11.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.12
+++ b/share/php-build/definitions/5.6.12
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.12.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.13
+++ b/share/php-build/definitions/5.6.13
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.13.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.14
+++ b/share/php-build/definitions/5.6.14
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.14.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.15
+++ b/share/php-build/definitions/5.6.15
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.15.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.16
+++ b/share/php-build/definitions/5.6.16
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.16.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.17
+++ b/share/php-build/definitions/5.6.17
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.17.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.18
+++ b/share/php-build/definitions/5.6.18
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.18.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.19
+++ b/share/php-build/definitions/5.6.19
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.19.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.2
+++ b/share/php-build/definitions/5.6.2
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.2.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.20
+++ b/share/php-build/definitions/5.6.20
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.20.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.21
+++ b/share/php-build/definitions/5.6.21
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.21.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.22
+++ b/share/php-build/definitions/5.6.22
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.22.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.23
+++ b/share/php-build/definitions/5.6.23
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.23.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.24
+++ b/share/php-build/definitions/5.6.24
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.24.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.25
+++ b/share/php-build/definitions/5.6.25
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.25.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.26
+++ b/share/php-build/definitions/5.6.26
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.26.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.27
+++ b/share/php-build/definitions/5.6.27
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.27.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.28
+++ b/share/php-build/definitions/5.6.28
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.28.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.29
+++ b/share/php-build/definitions/5.6.29
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.29.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.3
+++ b/share/php-build/definitions/5.6.3
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.3.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.30
+++ b/share/php-build/definitions/5.6.30
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.30.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.4
+++ b/share/php-build/definitions/5.6.4
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.4.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.5
+++ b/share/php-build/definitions/5.6.5
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.5.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.6
+++ b/share/php-build/definitions/5.6.6
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.6.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.7
+++ b/share/php-build/definitions/5.6.7
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.7.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.8
+++ b/share/php-build/definitions/5.6.8
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.8.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.9
+++ b/share/php-build/definitions/5.6.9
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package "https://secure.php.net/distributions/php-5.6.9.tar.bz2"
 install_xdebug "2.5.2"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6snapshot
+++ b/share/php-build/definitions/5.6snapshot
@@ -1,3 +1,5 @@
+configure_option -R "--with-mysql" "mysqlnd"
+
 install_package_from_github PHP-5.6
 install_xdebug "2.5.2"
 enable_builtin_opcache


### PR DESCRIPTION
Set `--with-mysql` it in each version's definition prior to 7.0.0 as a `configure_option`.

Fixes #348