### PR TITLE
Apply patches before configuring

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -336,12 +336,12 @@ function build_package() {
     if [ ! -d "$PREFIX" ]; then
         mkdir -p "$PREFIX"
     fi
+    
+    apply_patches "$source_path" 2>&4
 
     configure_package "$source_path"
 
     trigger_before_install "$source_path" 2>&4
-
-    apply_patches "$source_path" 2>&4
 
     log "Compiling" "$source_path"
 


### PR DESCRIPTION
In some cases one may want to patch the configure script for older versions of PHP.