### PR TITLE
Let the build fail when any unit test fails

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -41,14 +41,22 @@ echo
 for definition in $BUILD_LIST; do
     echo -n "Building '$definition'..."
     if ./bin/php-build "$definition" "$BUILD_PREFIX/$definition"; then
-        echo "OK"
+        echo "BUILD OK"
 
         export TEST_PREFIX="$BUILD_PREFIX/$definition"
+        export DEFINITION_CONFIG=$(./bin/php-build --definition "$definition")
+        export PHP_MINOR_VERSION=${definition%.*}
 
         echo "Running Tests..."
-        bats "tests/"
+
+        if bats "tests/"; then
+            echo "TEST OK"
+        else
+            echo "TEST FAIL"
+            FAILED="$FAILED $definition"
+        fi
     else
-        echo "FAIL"
+        echo "BUILD FAIL"
         FAILED="$FAILED $definition"
     fi
 done

--- a/tests/extensions.bats
+++ b/tests/extensions.bats
@@ -10,10 +10,12 @@
     echo "$output" | grep -q '^ftp$'
     echo "$output" | grep -q '^gd$'
     echo "$output" | grep -q '^libxml$'
-    echo "$output" | grep -q '^mcrypt$'
+    # mcrypt is removed from the core in PHP 7.2.0
+    [[ $PHP_MINOR_VERSION < 7.2 ]] && echo "$output" | grep -q '^mcrypt$'
     echo "$output" | grep -q '^mbstring$'
     echo "$output" | grep -q '^mysqli$'
-    [ "${TEST_PREFIX##*/}" != "5.2.17" ] && echo "$output" | grep -q '^mysqlnd$'
+    # mysqlnd is introduced since PHP 5.3.0
+    [[ $PHP_MINOR_VERSION > 5.2 ]] && echo "$output" | grep -q '^mysqlnd$'
     echo "$output" | grep -q '^openssl$'
     echo "$output" | grep -q '^pcre$'
     echo "$output" | grep -q '^pdo_mysql$'

--- a/tests/xdebug.bats
+++ b/tests/xdebug.bats
@@ -1,12 +1,17 @@
 #!/usr/bin/env bats
 
 @test "Installs xdebug.so" {
+    local xdebug_installed="$(echo "$DEFINITION_CONFIG" | grep '^install_xdebug')"
     local ext_dir=$("$TEST_PREFIX/bin/php" -r "echo ini_get('extension_dir');")
 
+    [ -z $xdebug_installed ] && skip "Xdebug isn't installed"
     [ -f "$ext_dir/xdebug.so" ]
 }
 
-@test "Enables XDebug" {
+@test "Enables Xdebug" {
+    local xdebug_installed="$(echo "$DEFINITION_CONFIG" | grep '^install_xdebug')"
+
+    [ -z $xdebug_installed ] && skip "Xdebug isn't installed"
     "$TEST_PREFIX/bin/php" -i | grep "xdebug"
 }
 


### PR DESCRIPTION
Current `run-tests.sh` runs tests under `tests/`, however the result of tests are ignored. This PR lets the build fail when any unit test fails.

Additionally, fixes tests for existence check against xdebug and mcrypt.
