### PR TITLE
Enable intl extension by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     packages:
       - libmcrypt-dev
       - libtidy-dev
+      - libicu-dev
       - php5-cli
       - re2c
 
@@ -38,7 +39,7 @@ before_install:
             export LIBS="-lssl -lcrypto"
         fi
         brew update
-        brew install re2c libmcrypt openssl libxml2
+        brew install re2c libmcrypt openssl libxml2 icu4c
         if [[ "$DEFINITION" == "5.2.17" ]]; then
             brew install mysql
         fi

--- a/bin/php-build
+++ b/bin/php-build
@@ -338,11 +338,11 @@ function build_package() {
         mkdir -p "$PREFIX"
     fi
 
+    apply_patches "$source_path" 2>&4
+
     configure_package "$source_path"
 
     trigger_before_install "$source_path" 2>&4
-
-    apply_patches "$source_path" 2>&4
 
     log "Compiling" "$source_path"
 
@@ -553,6 +553,10 @@ function configure_package() {
     if is_osx && [ "$(osx_major)" -eq 10 ] && [ "$(osx_minor)" -ge 11 ] && [ -n "$(which brew)" ] && [ -e "$(brew --prefix openssl)" ] && [ -e "$(brew --prefix libxml2)" ]; then
         configure_option -R "--with-openssl" "$(brew --prefix openssl)"
         configure_option -R "--with-libxml-dir" "$(brew --prefix libxml2)"
+    fi
+
+    if is_osx && [ -n "$(which brew)" ] && [ -e "$(brew --prefix icu4c)" ]; then
+        configure_option "--with-icu-dir" "$(brew --prefix icu4c)"
     fi
 
     CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $PHP_BUILD_CONFIGURE_OPTS $CONFIGURE_OPTS"

--- a/share/php-build/default_configure_options
+++ b/share/php-build/default_configure_options
@@ -8,6 +8,7 @@
 --with-zlib
 --with-zlib-dir=/usr
 --with-bz2
+--enable-intl
 --with-kerberos
 --with-openssl
 --with-mcrypt=/usr

--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -1,5 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.10.tar.bz2;h=e81d7ff32deb09b4e514540a181b583e681e3423;hb=483968fd35676f02e2cfbe01108afe2f4510e4ab"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -1,5 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.11.tar.bz2;h=5da1e305b9a2294264610a6d756c38386f3d6397;hb=1be2f72633b0a8ecc1a01fe23acb9253fea71c63"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -1,5 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.12.tar.bz2;h=54792f190cdafe33dd4e2e0100076ad33f9edc6c;hb=7d42906904247fbe3cf1bdb1ec945628fc24af8c"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -1,5 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.13.tar.bz2;h=3ca3e799c3e24eec433669b956ab21763430bc21;hb=fc98a2ea17a9f6fddcc28207ebee4904619e19a2"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -1,5 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.14.tar.bz2;h=36088f2c5dd0cf480030dc7f91ce7efc0026e034;hb=5166081c36f1170c175e1913179a1559434c77a8"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -1,5 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.15.tar.bz2;h=bb661f88f9fdf66973bf88f68e626b7ba0d76c35;hb=9d55e80bd741bc0eefa5c5fb1e4fb7c45f2398f5"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -1,5 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.16.tar.bz2;h=0b4c03fb4c250d4aaa5d7d5bf3a13b0a0b17a185;hb=72ad55a500ace2d6f46c4e88f078bac52f11e99c"

--- a/share/php-build/definitions/5.3.17
+++ b/share/php-build/definitions/5.3.17
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.17.tar.bz2;h=5b8477ff1e267359d2b3f1b6d0ae8ae3672af89d;hb=6e47872b79b12476db045f97882ed55480bcd021"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.18
+++ b/share/php-build/definitions/5.3.18
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.18.tar.bz2;h=0453a3ccc7ed29923e2c96d067127d108b4975d6;hb=0251f33df31f77f31c23822772980ca35f3d56a0"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.19
+++ b/share/php-build/definitions/5.3.19
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.19.tar.bz2;h=666ec3f90a28467f97e956589e38c3598918af32;hb=186d0ee2e8600ca14691d7a6bd5833dd6d01542c"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.2.tar.bz2;h=69f6e396a0898af2d528d0826704460327191eee;hb=68deb8a9489af4c64ce4bb50e93db6328ddaf4e9"

--- a/share/php-build/definitions/5.3.20
+++ b/share/php-build/definitions/5.3.20
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.20.tar.bz2;h=87a7017b1bc5bcb85ba193486073bf9bf2091b23;hb=ff93ccb17ec622df93c785eb6b579330b9dc6693"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.21
+++ b/share/php-build/definitions/5.3.21
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.21.tar.bz2;h=0d1190369147893601eb50350c5351b8af15b5eb;hb=79e859d6ef335aca213dfced182ea790f6d89090"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.22
+++ b/share/php-build/definitions/5.3.22
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.22.tar.bz2;h=eb6fc208fac9da05251ab891a704bae3cb6acec4;hb=31b7806f2afaf85e7caa9e73491d1c842500543a"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.23
+++ b/share/php-build/definitions/5.3.23
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.23.tar.bz2;h=d82389aa0bbdd72a78333c55d8ec6537ca9eba17;hb=8df98dc7857d7576a2540c5b2fb952b4a8cea4b5"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.24
+++ b/share/php-build/definitions/5.3.24
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.24.tar.bz2;h=42f459aeb6914b192fb589e6251338d8e39d0264;hb=3dd2f12609fc8a730d7cf341a932f6c7b241f03c"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.25
+++ b/share/php-build/definitions/5.3.25
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.25.tar.bz2;h=3f7d55b74ae3bd32a8556f72bc3f66f3d0193a94;hb=456ff125bac581ad3c0a464a7944393f85079101"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.26
+++ b/share/php-build/definitions/5.3.26
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.26.tar.bz2;h=365d98c941570776c7db266ed07784d7060e03b9;hb=a6730f389cd3a53bc640f874a754f8f79c7c3089"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.27
+++ b/share/php-build/definitions/5.3.27
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://secure.php.net/distributions/php-5.3.27.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.28
+++ b/share/php-build/definitions/5.3.28
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://secure.php.net/distributions/php-5.3.28.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.29
+++ b/share/php-build/definitions/5.3.29
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
+
 install_package "https://secure.php.net/distributions/php-5.3.29.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.3.tar.bz2;h=c473d92b8399ed7dfc995864d8c0987041300a22;hb=b142c68a1bc6ef1eb24fc61fed1b4bf702b4751f"

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "xp_ssl.c.patch"
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.6.tar.bz2;h=70fcfecaaa6c58d20a1a8080a7d68e111bb8f9ba;hb=ff4121c1cdebd9248ee7d5726e1abd8c0218cac9"

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -1,5 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.8.tar.bz2;h=9740dd93a54ad4216bb43baaefeb8b0bc219861b;hb=bc2bfc2a0c93a8cc8ed5fa56d51f59c2d5615a80"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -1,5 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.9.tar.bz2;h=2a0bceb5f921a74433e318d638d84adcbbf14756;hb=ded0904f93cb86fbb23f5b4d5790c8df500b7bf7"

--- a/share/php-build/patches/php-5.3.29-64bit-intl.patch
+++ b/share/php-build/patches/php-5.3.29-64bit-intl.patch
@@ -1,0 +1,49 @@
+Fix for PHP bug 48795 (https://bugs.php.net/bug.php?id=48795)
+This patch provides support for intl extension in PHP < 5.4.0 on x86_64
+diff -c -r php-5.3.29-orig/acinclude.m4 php-5.3.29/acinclude.m4
+*** php-5.3.29-orig/acinclude.m4	2014-08-14 04:22:50.000000000 +0900
+--- php-5.3.29/acinclude.m4	2017-07-22 19:16:33.000000000 +0900
+***************
+*** 762,767 ****
+--- 762,768 ----
+    if test -z "$php_cxx_done"; then
+      AC_PROG_CXX
+      AC_PROG_CXXCPP
++     PHP_ADD_LIBRARY(stdc++)
+      php_cxx_done=yes
+    fi
+  ])
+diff -c -r php-5.3.29-orig/aclocal.m4 php-5.3.29/aclocal.m4
+*** php-5.3.29-orig/aclocal.m4	2014-08-14 04:27:27.000000000 +0900
+--- php-5.3.29/aclocal.m4	2017-07-22 19:16:56.000000000 +0900
+***************
+*** 762,767 ****
+--- 762,768 ----
+    if test -z "$php_cxx_done"; then
+      AC_PROG_CXX
+      AC_PROG_CXXCPP
++     PHP_ADD_LIBRARY(stdc++)
+      php_cxx_done=yes
+    fi
+  ])
+diff -c -r php-5.3.29-orig/configure php-5.3.29/configure
+*** php-5.3.29-orig/configure	2014-08-14 04:27:27.000000000 +0900
+--- php-5.3.29/configure	2017-07-22 22:25:03.000000000 +0900
+***************
+*** 52880,52885 ****
+--- 52880,52895 ----
+  CXXCPP="$ac_cv_prog_CXXCPP"
+  echo "$ac_t""$CXXCPP" 1>&6
+  
++     
++   
++   case stdc++ in
++   c|c_r|pthread*) ;;
++   *) 
++       LIBS="-lstdc++ $LIBS" 
++    ;;
++   esac
++ 
++ 
+      php_cxx_done=yes
+    fi

--- a/tests/extensions.bats
+++ b/tests/extensions.bats
@@ -9,6 +9,8 @@
     echo "$output" | grep -q '^exif$'
     echo "$output" | grep -q '^ftp$'
     echo "$output" | grep -q '^gd$'
+    # intl is introduced since PHP 5.3.0
+    [[ $PHP_MINOR_VERSION > 5.2 ]] && echo "$output" | grep -q '^intl$'
     echo "$output" | grep -q '^libxml$'
     # mcrypt is removed from the core in PHP 7.2.0
     [[ $PHP_MINOR_VERSION < 7.2 ]] && echo "$output" | grep -q '^mcrypt$'


### PR DESCRIPTION
This PR enables intl extension by default.

Some PHP frameworks require the intl extension, such as Symfony2 and CakePHP3. So it's useful for php-build to enable the intl extension by default.

In addition, there's problem for building intl extension with PHP 5.3.x on 64bit architechture (see: [PHP Bug #48795](https://bugs.php.net/bug.php?id=48795) ). I wrote patch against this problem (`php-5.3.29-64bit-intl.patch`).

This patch fixes `configure` script. Current `php-build` applies patches after running `configure` script, so we cannot fix `configure` behavior. This PR changes the patch application timing to fix `configure` behavior.
