### PR TITLE
Allow custom temporary directory

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -61,7 +61,17 @@ function realpath() {
 # This is the path where php-build is installed. This is treated as the base for
 # the `share/` and `tmp/` folders of php-build.
 PHP_BUILD_ROOT="$(realpath "$0")/.."
-TMP="$(dirname $(mktemp --dry-run 2>/dev/null || echo "/var/tmp/tmp_dir"))/php-build"
+
+if [ ! -d "$PHP_BUILD_TMPDIR" ]; then
+    if [ -d "$TMPDIR" ]; then
+        PHP_BUILD_TMPDIR=$TMPDIR/php-build
+    else
+        PHP_BUILD_TMPDIR="$(dirname $(mktemp --dry-run 2>/dev/null || echo "/var/tmp/tmp_dir"))/php-build"
+    fi
+fi
+
+# set ${TMP} for backward compatibility
+TMP=$PHP_BUILD_TMPDIR
 
 # This file gets copied to `$PREFIX/etc/php.ini` once the build is complete.
 # This is by default the PHP tarball's `php.ini-production`.
@@ -107,16 +117,16 @@ function display_version() {
 
 # Init the directories on first run
 function init() {
-    if [ ! -d "$TMP" ]; then
-        mkdir -p "$TMP"
+    if [ ! -d "$PHP_BUILD_TMPDIR" ]; then
+        mkdir -p "$PHP_BUILD_TMPDIR"
     fi
 
-    if [ ! -d "$TMP/packages" ]; then
-        mkdir "$TMP/packages"
+    if [ ! -d "$PHP_BUILD_TMPDIR/packages" ]; then
+        mkdir "$PHP_BUILD_TMPDIR/packages"
     fi
 
-    if [ ! -d "$TMP/source" ]; then
-        mkdir "$TMP/source"
+    if [ ! -d "$PHP_BUILD_TMPDIR/source" ]; then
+        mkdir "$PHP_BUILD_TMPDIR/source"
     fi
 
     if [ ! -d "$PHP_BUILD_ROOT/share/php-build/before-install.d" ]; then
@@ -199,19 +209,19 @@ function osx_minor {
     return 0
 }
 
-# Downloads a PHP Source Tarball and extracts it to `$TMP/source/$DEFINITION`
+# Downloads a PHP Source Tarball and extracts it to `$PHP_BUILD_TMPDIR/source/$DEFINITION`
 function download() {
     local url=$1
     local basename=$(download_filename $url)
-    local package_file="$TMP/packages/$basename"
+    local package_file="$PHP_BUILD_TMPDIR/packages/$basename"
     local archive_type=$2
-    local temp_package="$TMP/$basename"
+    local temp_package="$PHP_BUILD_TMPDIR/$basename"
 
     if [ -z $archive_type ]; then
         archive_type=${package_file##*.}
     fi
 
-    if [ -d "$TMP/source/$DEFINITION" ]; then
+    if [ -d "$PHP_BUILD_TMPDIR/source/$DEFINITION" ]; then
         log "Skipping" "Already downloaded and extracted $url"
         return
     fi
@@ -226,13 +236,13 @@ function download() {
     # Do not download a package when it's already downloaded.
     if [ ! -f "$package_file" ]; then
         http get "$url" > "$temp_package"
-        cp "$temp_package" "$TMP/packages"
+        cp "$temp_package" "$PHP_BUILD_TMPDIR/packages"
         rm "$temp_package"
     fi
 
-    mkdir "$TMP/source/$DEFINITION"
+    mkdir "$PHP_BUILD_TMPDIR/source/$DEFINITION"
 
-    "extract_$archive_type" "$package_file" "$TMP/source/$DEFINITION"
+    "extract_$archive_type" "$package_file" "$PHP_BUILD_TMPDIR/source/$DEFINITION"
 }
 
 function download_filename() {
@@ -331,7 +341,7 @@ function build_package() {
     local source_path=$1
     local cwd="$(pwd)"
     if [ -z $1 ]; then
-      local source_path="$TMP/source/$DEFINITION"
+      local source_path="$PHP_BUILD_TMPDIR/source/$DEFINITION"
     fi
 
     if [ ! -d "$PREFIX" ]; then
@@ -425,7 +435,7 @@ function install_package() {
 
     {
         download $url $archive_type
-        cd "$TMP/source/$DEFINITION"
+        cd "$PHP_BUILD_TMPDIR/source/$DEFINITION"
         build_package
         cd - > /dev/null
     } >&4 2>&1
@@ -635,7 +645,7 @@ function build_error() {
 function cleanup_abort() {
     log "Warn" "Aborting build."
 
-    make -C "$TMP/source/$DEFINITION" clean &> /dev/null
+    make -C "$PHP_BUILD_TMPDIR/source/$DEFINITION" clean &> /dev/null
 }
 
 function find_definition() {

--- a/man/php-build.5
+++ b/man/php-build.5
@@ -86,7 +86,7 @@ The absolute path to the definition file which was sourced\.
 The path where source files will be built into\.
 .
 .TP
-\fBTMP\fR
+\fBPHP_BUILD_TMPDIR\fR
 Path for (persistent) temporary files\.
 .
 .TP

--- a/man/php-build.5.html
+++ b/man/php-build.5.html
@@ -147,7 +147,7 @@ as well as all builtin commands.</p>
 file path was passed as definition, then this contains the path's basename.</dd>
 <dt><code>DEFINITION_PATH</code></dt><dd>The absolute path to the definition file which was sourced.</dd>
 <dt class="flush"><code>PREFIX</code></dt><dd>The path where source files will be built into.</dd>
-<dt class="flush"><code>TMP</code></dt><dd>Path for (persistent) temporary files.</dd>
+<dt class="flush"><code>PHP_BUILD_TMPDIR</code></dt><dd>Path for (persistent) temporary files.</dd>
 <dt><code>CONFIGURE_OPTIONS</code></dt><dd>Argument list passed to <code>configure</code>, separated by line feeds.</dd>
 <dt><code>PHP_BUILD_ROOT</code></dt><dd>Root of the <span class="man-ref">php-build<span class="s">(1)</span></span> install, for example <code>/usr/local</code>.</dd>
 <dt><code>LOG_PATH</code></dt><dd>Path to the currently used log file.</dd>

--- a/man/php-build.5.ronn
+++ b/man/php-build.5.ronn
@@ -78,7 +78,7 @@ as well as all builtin commands.
    The absolute path to the definition file which was sourced.
  * `PREFIX`:
    The path where source files will be built into.
- * `TMP`:
+ * `PHP_BUILD_TMPDIR`:
    Path for (persistent) temporary files.
  * `CONFIGURE_OPTIONS`:
    Argument list passed to `configure`, separated by line feeds.

--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -62,26 +62,26 @@ function _download_extension {
     local source_dir=$(eval basename ${url%.*})
 
      # We cache the tarballs for APC versions in `packages/`.
-    if [ ! -f "$TMP/packages/$name-$version.tgz" ]; then
-        http get "$package_url" > "$TMP/packages/$package_name.tgz"
+    if [ ! -f "$PHP_BUILD_TMPDIR/packages/$name-$version.tgz" ]; then
+        http get "$package_url" > "$PHP_BUILD_TMPDIR/packages/$package_name.tgz"
     fi
 
     # Each tarball gets extracted to `source/$name-$version`.
-    if [ -d "$TMP/source/$package_name" ]; then
-        rm -rf "$TMP/source/$package_name"
+    if [ -d "$PHP_BUILD_TMPDIR/source/$package_name" ]; then
+        rm -rf "$PHP_BUILD_TMPDIR/source/$package_name"
     fi
 
-    tar -xzf "$TMP/packages/$package_name.tgz" -C "$TMP/source"
+    tar -xzf "$PHP_BUILD_TMPDIR/packages/$package_name.tgz" -C "$PHP_BUILD_TMPDIR/source"
 
     # change the directory name for APC since it expands with an uppercase filename
-    if [[ ! -d $TMP/source/$package_name && -d $TMP/source/$source_dir ]]; then
-      mv $TMP/source/$source_dir $TMP/source/$package_name
+    if [[ ! -d $PHP_BUILD_TMPDIR/source/$package_name && -d $PHP_BUILD_TMPDIR/source/$source_dir ]]; then
+      mv $PHP_BUILD_TMPDIR/source/$source_dir $PHP_BUILD_TMPDIR/source/$package_name
     fi
 
-    [[ -f "$TMP/source/package.xml" ]] && rm "$TMP/source/package.xml"
-    [[ -f "$TMP/source/package2.xml" ]] && rm "$TMP/source/package2.xml"
+    [[ -f "$PHP_BUILD_TMPDIR/source/package.xml" ]] && rm "$PHP_BUILD_TMPDIR/source/package.xml"
+    [[ -f "$PHP_BUILD_TMPDIR/source/package2.xml" ]] && rm "$PHP_BUILD_TMPDIR/source/package2.xml"
 
-    _build_extension "$TMP/source/$package_name" $name "" "$configure_args" \
+    _build_extension "$PHP_BUILD_TMPDIR/source/$package_name" $name "" "$configure_args" \
         $extension_type "$after_install"
 }
 
@@ -93,7 +93,7 @@ function _checkout_extension {
     local configure_args="$5"
     local extension_type="$6"
     local after_install="$7"
-    local source_dir="$TMP/source/$name-master"
+    local source_dir="$PHP_BUILD_TMPDIR/source/$name-master"
 
     if [ -d "$source_dir" ] && [ -d "$source_dir/.git" ]; then
         log "$name" "Updating $name from Git Master"

--- a/share/php-build/plugins.d/composer.sh
+++ b/share/php-build/plugins.d/composer.sh
@@ -20,15 +20,15 @@ download_composer() {
         composer_url="https://getcomposer.org/composer.phar"
     fi
 
-    if [ ! -f "$TMP/packages/composer.phar" ]; then
+    if [ ! -f "$PHP_BUILD_TMPDIR/packages/composer.phar" ]; then
         log Composer "Downloading from $composer_url"
-        wget -P "$TMP/packages" $composer_url
+        wget -P "$PHP_BUILD_TMPDIR/packages" $composer_url
     else
-        log Composer "self updating in $TMP/packages/composer.phar"
-        $PHP $TMP/packages/composer.phar self-update
+        log Composer "self updating in $PHP_BUILD_TMPDIR/packages/composer.phar"
+        $PHP $PHP_BUILD_TMPDIR/packages/composer.phar self-update
     fi
 }
 
 copy_composer_phar() {
-    yes | cp "$TMP/packages/composer.phar" "$PREFIX/bin/composer.phar"
+    yes | cp "$PHP_BUILD_TMPDIR/packages/composer.phar" "$PREFIX/bin/composer.phar"
 }

--- a/share/php-build/plugins.d/github.sh
+++ b/share/php-build/plugins.d/github.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 # Downloads a PHP Source Tarball from GitHub and extracts it to
-# `${TMP}/source/${DEFINITION}`.
+# `${PHP_BUILD_TMPDIR}/source/${DEFINITION}`.
 function download_from_github() {
     local branch=${1}
     local repository_name=${2}
-    local package_file="${TMP}/packages/${branch}.tar.gz"
+    local package_file="${PHP_BUILD_TMPDIR}/packages/${branch}.tar.gz"
     local package_url="https://github.com/${repository_name}/tarball/${branch}"
-    local package_temporary="${TMP}/${branch}.tar.gz"
+    local package_temporary="${PHP_BUILD_TMPDIR}/${branch}.tar.gz"
 
-    if [ -d "${TMP}/source/${DEFINITION}" ]; then
+    if [ -d "${PHP_BUILD_TMPDIR}/source/${DEFINITION}" ]; then
         log "Removing" "Already downloaded and extracted ${package_url}"
-        rm -rf "${TMP}/source/${DEFINITION}"
+        rm -rf "${PHP_BUILD_TMPDIR}/source/${DEFINITION}"
     fi
 
     log "Downloading" "${package_url}"
@@ -22,21 +22,21 @@ function download_from_github() {
     fi
 
     http get "${package_url}" > ${package_temporary}
-    cp "${package_temporary}" "${TMP}/packages"
+    cp "${package_temporary}" "${PHP_BUILD_TMPDIR}/packages"
     rm "${package_temporary}"
 
-    mkdir "${TMP}/source/${DEFINITION}"
+    mkdir "${PHP_BUILD_TMPDIR}/source/${DEFINITION}"
 
-    extract_gz "${package_file}" "${TMP}/source/${DEFINITION}"
+    extract_gz "${package_file}" "${PHP_BUILD_TMPDIR}/source/${DEFINITION}"
 }
 
 # ### clone_from_github
-# Clones a source from GitHub and extracts it to `${TMP}/source/${DEFINITION}`.
+# Clones a source from GitHub and extracts it to `${PHP_BUILD_TMPDIR}/source/${DEFINITION}`.
 function clone_from_github() {
     local branch=${1}
     local repository_name=${2}
     local repository_url="git://github.com/${repository_name}.git"
-    local directory="${TMP}/source/${DEFINITION}"
+    local directory="${PHP_BUILD_TMPDIR}/source/${DEFINITION}"
 
     if [ -d "${directory}" ]; then
         log "Removing" "Already cloned branch ${branch} from ${repository_url}"
@@ -59,7 +59,7 @@ function install_package_from_github() {
 
     {
         clone_from_github ${branch} ${repository_name}
-        cd "${TMP}/source/${DEFINITION}"
+        cd "${PHP_BUILD_TMPDIR}/source/${DEFINITION}"
         build_package
         cd - > /dev/null
     } >&4 2>&1


### PR DESCRIPTION
See also: #170

This PR introduce new environment variable `$PHP_BUILD_TMPDIR`. By setting `$PHP_BUILD_TMPDIR`, we can specify the temporary directory for php-build.

Additionally, the default temporary path is also changed. If `$TMPDIR` is set, the default temporary path is set based on `$TMPDIR`. This should be desirable behavior for many UNIX-like systems.
