### PR TITLE
Log error messages from phpize

### DIFF
--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -132,7 +132,7 @@ function _build_extension {
     cd "$source_dir/$source_cwd"
 
     {
-        $PREFIX/bin/phpize > /dev/null
+        $PREFIX/bin/phpize 1>&2
         "$(pwd)/configure" --with-php-config=$PREFIX/bin/php-config \
             $configure_args > /dev/null
 


### PR DESCRIPTION
When executing external command in `php-build`, we expect the error message from the command will be displayed on stderr and no critical message will never be displayed on stdout. So We usually redirect stdout from the commands to `/dev/null`.

However,  all messages of the `phpize` command is displayed on stdout (including error message), so all error message will ignored even if the critical error occurred when we execute `phpize` in `php-build`.

For example, `phpize` displays the following error on stdout when we have no `autoconf` command. But `php-build` never log this messages.

```
Cannot find autoconf. Please check your autoconf installation and the
$PHP_AUTOCONF environment variable. Then, rerun this script.
```

The cause of the problem is not `php-build` but `phpize`, however we need the workarounds for it.
