### PR TITLE
Support C++11 for ICU4C 59+

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -567,6 +567,10 @@ function configure_package() {
 
     if is_osx && [ -n "$(which brew)" ] && [ -e "$(brew --prefix icu4c)" ]; then
         configure_option "--with-icu-dir" "$(brew --prefix icu4c)"
+        # icu4c 59+ requires C++11
+        if [[ -z "$CXXFLAGS" && $($(brew --prefix icu4c)/bin/icu-config --version) > "59" ]]; then
+            export CXXFLAGS="-std=c++11 -stdlib=libc++"
+        fi
     fi
 
     CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $PHP_BUILD_CONFIGURE_OPTS $CONFIGURE_OPTS"

--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.10.tar.bz2;h=e81d7ff32deb09b4e514540a181b583e681e3423;hb=483968fd35676f02e2cfbe01108afe2f4510e4ab"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.11.tar.bz2;h=5da1e305b9a2294264610a6d756c38386f3d6397;hb=1be2f72633b0a8ecc1a01fe23acb9253fea71c63"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.12.tar.bz2;h=54792f190cdafe33dd4e2e0100076ad33f9edc6c;hb=7d42906904247fbe3cf1bdb1ec945628fc24af8c"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.13.tar.bz2;h=3ca3e799c3e24eec433669b956ab21763430bc21;hb=fc98a2ea17a9f6fddcc28207ebee4904619e19a2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.14.tar.bz2;h=36088f2c5dd0cf480030dc7f91ce7efc0026e034;hb=5166081c36f1170c175e1913179a1559434c77a8"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.15.tar.bz2;h=bb661f88f9fdf66973bf88f68e626b7ba0d76c35;hb=9d55e80bd741bc0eefa5c5fb1e4fb7c45f2398f5"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.16.tar.bz2;h=0b4c03fb4c250d4aaa5d7d5bf3a13b0a0b17a185;hb=72ad55a500ace2d6f46c4e88f078bac52f11e99c"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.17
+++ b/share/php-build/definitions/5.3.17
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.17.tar.bz2;h=5b8477ff1e267359d2b3f1b6d0ae8ae3672af89d;hb=6e47872b79b12476db045f97882ed55480bcd021"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.18
+++ b/share/php-build/definitions/5.3.18
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.18.tar.bz2;h=0453a3ccc7ed29923e2c96d067127d108b4975d6;hb=0251f33df31f77f31c23822772980ca35f3d56a0"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.19
+++ b/share/php-build/definitions/5.3.19
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.19.tar.bz2;h=666ec3f90a28467f97e956589e38c3598918af32;hb=186d0ee2e8600ca14691d7a6bd5833dd6d01542c"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -4,6 +4,7 @@ patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.2.tar.bz2;h=69f6e396a0898af2d528d0826704460327191eee;hb=68deb8a9489af4c64ce4bb50e93db6328ddaf4e9"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.20
+++ b/share/php-build/definitions/5.3.20
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.20.tar.bz2;h=87a7017b1bc5bcb85ba193486073bf9bf2091b23;hb=ff93ccb17ec622df93c785eb6b579330b9dc6693"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.21
+++ b/share/php-build/definitions/5.3.21
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.21.tar.bz2;h=0d1190369147893601eb50350c5351b8af15b5eb;hb=79e859d6ef335aca213dfced182ea790f6d89090"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.22
+++ b/share/php-build/definitions/5.3.22
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.22.tar.bz2;h=eb6fc208fac9da05251ab891a704bae3cb6acec4;hb=31b7806f2afaf85e7caa9e73491d1c842500543a"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.23
+++ b/share/php-build/definitions/5.3.23
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.23.tar.bz2;h=d82389aa0bbdd72a78333c55d8ec6537ca9eba17;hb=8df98dc7857d7576a2540c5b2fb952b4a8cea4b5"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.24
+++ b/share/php-build/definitions/5.3.24
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.24.tar.bz2;h=42f459aeb6914b192fb589e6251338d8e39d0264;hb=3dd2f12609fc8a730d7cf341a932f6c7b241f03c"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.25
+++ b/share/php-build/definitions/5.3.25
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.25.tar.bz2;h=3f7d55b74ae3bd32a8556f72bc3f66f3d0193a94;hb=456ff125bac581ad3c0a464a7944393f85079101"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.26
+++ b/share/php-build/definitions/5.3.26
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.26.tar.bz2;h=365d98c941570776c7db266ed07784d7060e03b9;hb=a6730f389cd3a53bc640f874a754f8f79c7c3089"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.27
+++ b/share/php-build/definitions/5.3.27
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://secure.php.net/distributions/php-5.3.27.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.28
+++ b/share/php-build/definitions/5.3.28
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://secure.php.net/distributions/php-5.3.28.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.29
+++ b/share/php-build/definitions/5.3.29
@@ -1,6 +1,8 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
+patch_file "php-5.4.12-support-c++11.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://secure.php.net/distributions/php-5.3.29.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -4,6 +4,7 @@ patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.3.tar.bz2;h=c473d92b8399ed7dfc995864d8c0987041300a22;hb=b142c68a1bc6ef1eb24fc61fed1b4bf702b4751f"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -3,6 +3,7 @@ configure_option "--with-mysql" "mysqlnd"
 patch_file "xp_ssl.c.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.6.tar.bz2;h=70fcfecaaa6c58d20a1a8080a7d68e111bb8f9ba;hb=ff4121c1cdebd9248ee7d5726e1abd8c0218cac9"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.8.tar.bz2;h=9740dd93a54ad4216bb43baaefeb8b0bc219861b;hb=bc2bfc2a0c93a8cc8ed5fa56d51f59c2d5615a80"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -2,6 +2,7 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.3.9.tar.bz2;h=2a0bceb5f921a74433e318d638d84adcbbf14756;hb=ded0904f93cb86fbb23f5b4d5790c8df500b7bf7"
 install_xdebug "2.2.7"

--- a/share/php-build/definitions/5.4.0
+++ b/share/php-build/definitions/5.4.0
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.0.tar.bz2;h=c6b90d8907d2f695cee4b9ba99e50e5f84ebb24f;hb=108d84532bb7dbc402baa547906f4b8c8b385247"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.1
+++ b/share/php-build/definitions/5.4.1
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.1.tar.bz2;h=af3337316638a3060016bd1a2484f3967918d7b0;hb=9362c63c2734d4207456c1bf156033006f8f084b"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.10
+++ b/share/php-build/definitions/5.4.10
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.4.12-support-c++11.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.10.tar.bz2;h=4dbf54e08ee2fb77028aeefb5b03ee0713856a6c;hb=ee8236662d9af60e8f6c32212531bc16bb175266"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.11
+++ b/share/php-build/definitions/5.4.11
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.4.12-support-c++11.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.11.tar.bz2;h=f1218b7345d8724b03061db374dccf8b3ff316e4;hb=e674fe7c2e0ba52772a723047a5b5ffc8db3bfb7"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.12
+++ b/share/php-build/definitions/5.4.12
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.4.12-support-c++11.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.12.tar.bz2;h=36a855340fa72973a958d03827fa07a5b75cceed;hb=eb78a1bdd2dcdc1450420b592fb7c60a93bcb5b9"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.2
+++ b/share/php-build/definitions/5.4.2
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.2.tar.bz2;h=beaf09392b3dbd2a6d1d7b9fe4a1a666b02c3cf8;hb=dc9af806a66c6bcc3b59d15a289a35304a2e3155"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.3
+++ b/share/php-build/definitions/5.4.3
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.3.tar.bz2;h=94ad3994b566844cbd4ab296b6feec596cb733f5;hb=7f8220645a75deb245db5a1ce8dc53827931ec43"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.4
+++ b/share/php-build/definitions/5.4.4
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.4.tar.bz2;h=b4b19234b19f5c00345abdd5fc15b4962a25406e;hb=91ccf2ea2f466a5a012cbee00db3eea7b3ed5564"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.5
+++ b/share/php-build/definitions/5.4.5
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.5.tar.bz2;h=12181dfd61374540375e1d7b77576888ab5548c5;hb=9d55e80bd741bc0eefa5c5fb1e4fb7c45f2398f5"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.6
+++ b/share/php-build/definitions/5.4.6
@@ -1,6 +1,7 @@
 configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
+patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.6.tar.bz2;h=e17d663484714d00244ffd8ab61898017571fc61;hb=c9ee21e0d046f234ee6f17faad475fff65373f95"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.7
+++ b/share/php-build/definitions/5.4.7
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.4.12-support-c++11.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.7.tar.bz2;h=718133ae425fa4236c6c17536959c07f18a1ee45;hb=5dde46e9635c40cb0515118a2e46ee015b14984e"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.8
+++ b/share/php-build/definitions/5.4.8
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.4.12-support-c++11.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.8.tar.bz2;h=336267f83d03428851e58477bccf1478211dcbe1;hb=64f1ac741d14dc9a1dbfbe9416619537a7cd2fba"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.9
+++ b/share/php-build/definitions/5.4.9
@@ -1,4 +1,6 @@
 configure_option "--with-mysql" "mysqlnd"
 
+patch_file "php-5.4.12-support-c++11.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.9.tar.bz2;h=452c44736d8391f5e1c89fab62ad47d553f40f4d;hb=685e095dd2b8443b8031a8d5628eabc556a89e1d"
 install_xdebug "2.4.1"

--- a/share/php-build/patches/php-5.4.12-support-c++11.patch
+++ b/share/php-build/patches/php-5.4.12-support-c++11.patch
@@ -1,0 +1,20 @@
+diff -r -c php-5.4.12-orig/Zend/zend_API.h php-5.4.12/Zend/zend_API.h
+*** php-5.4.12-orig/Zend/zend_API.h	2017-08-13 16:41:46.000000000 +0900
+--- php-5.4.12/Zend/zend_API.h	2017-08-13 16:42:41.000000000 +0900
+***************
+*** 60,66 ****
+  	zval *object_ptr;
+  } zend_fcall_info_cache;
+  
+! #define ZEND_NS_NAME(ns, name)			ns"\\"name
+  
+  #define ZEND_FN(name) zif_##name
+  #define ZEND_MN(name) zim_##name
+--- 60,66 ----
+  	zval *object_ptr;
+  } zend_fcall_info_cache;
+  
+! #define ZEND_NS_NAME(ns, name)			ns "\\" name
+  
+  #define ZEND_FN(name) zif_##name
+  #define ZEND_MN(name) zim_##name


### PR DESCRIPTION
Yesterday, homebrew updated icu4c package from 58.2 to 59.1. Then php-build on macOS got failed.

It seems that icu 59+ requires C++11. So I fixed `bin/php-build` to use C++11 compiler for macOS environment. I also add patch for PHP 5.3.0-5.4.12 because those version has a macro which is incompatible with C++11.