### PR TITLE
Enable Xdebug for PHP 7.2 again

### DIFF
--- a/share/php-build/definitions/7.2.0beta1
+++ b/share/php-build/definitions/7.2.0beta1
@@ -1,2 +1,3 @@
 install_package "https://downloads.php.net/~pollita/php-7.2.0beta1.tar.bz2"
+install_xdebug_master
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.0beta2
+++ b/share/php-build/definitions/7.2.0beta2
@@ -1,2 +1,3 @@
 install_package "https://downloads.php.net/~pollita/php-7.2.0beta2.tar.bz2"
+install_xdebug_master
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.0beta3
+++ b/share/php-build/definitions/7.2.0beta3
@@ -1,2 +1,3 @@
 install_package "https://downloads.php.net/~remi/php-7.2.0beta3.tar.bz2"
+install_xdebug_master
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2snapshot
+++ b/share/php-build/definitions/7.2snapshot
@@ -1,2 +1,3 @@
 install_package_from_github PHP-7.2
+install_xdebug_master
 enable_builtin_opcache

--- a/share/php-build/definitions/master
+++ b/share/php-build/definitions/master
@@ -1,2 +1,3 @@
 install_package_from_github master
+install_xdebug_master
 enable_builtin_opcache

--- a/share/php-build/definitions/master
+++ b/share/php-build/definitions/master
@@ -1,3 +1,2 @@
 install_package_from_github master
-install_xdebug_master
 enable_builtin_opcache


### PR DESCRIPTION
We disabled Xdebug on PHP 7.2 in #450.

Now the issue was fixed in [xdebug/xdebug #359](https://github.com/xdebug/xdebug/pull/359), so we can build Xdebug with PHP 7.2.
