### PR TITLE
Show the SHA1 hash of the head commit for the fetched extension

### DIFF
--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -116,8 +116,9 @@ function _checkout_extension {
         git pull origin master > /dev/null
         cd "$cwd"
     else
-        log "$name" "Fetching from Git Master"
-        git clone "$url_source" "$source_dir" > /dev/null
+        log "$name" "Fetching from $url_source"
+        git clone "$url_source" "$source_dir" 2>&4
+        log "$name" "commit $(cd ${source_dir} && git rev-parse HEAD)"
     fi
 
     if [ -n "$revision" ]; then


### PR DESCRIPTION
Just like #458,  I think it is better that SHA1 hash is displayed when fetching extension from repository.

Applying this PR, logs from php-build will be as follows:

```
[xdebug]: Installing from source
[xdebug]: Fetching from git://github.com/xdebug/xdebug.git
[xdebug]: commit 52adff7539109db592d07d3f6c325f6ee2a7669f
```