### PR TITLE
fix download URL for php 7.2.0RC5

### DIFF
--- a/share/php-build/definitions/7.2.0RC5
+++ b/share/php-build/definitions/7.2.0RC5
@@ -1,3 +1,3 @@
-install_package "https://downloads.php.net/~pollita/php-7.2.0RC5.tar.bz2"
+install_package "https://downloads.php.net/~pollita/php-7.2.0RC/php-7.2.0RC5.tar.bz2"
 install_xdebug_master
 enable_builtin_opcache


### PR DESCRIPTION
 - fixed the URL for php 7.2.0RC5. The file has been moved to `php-7.2.0RC` dir