### PR TITLE
Fix ICU4C 61.1 compatibility problem

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -573,7 +573,10 @@ function configure_package() {
     if is_osx && [ -n "$(which brew)" ] && [ -e "$(brew --prefix icu4c)" ]; then
         configure_option "--with-icu-dir" "$(brew --prefix icu4c)"
         # icu4c 59+ requires C++11
-        if [[ -z "$CXXFLAGS" && $($(brew --prefix icu4c)/bin/icu-config --version) > "59" ]]; then
+        if [[ -z "$CXXFLAGS" && $($(brew --prefix icu4c)/bin/icu-config --version) > "61" ]]; then
+            # icu4c 61+ compatability (see #499)
+            export CXXFLAGS="-std=c++11 -stdlib=libc++ -DU_USING_ICU_NAMESPACE=1"
+        elif [[ -z "$CXXFLAGS" && $($(brew --prefix icu4c)/bin/icu-config --version) > "59" ]]; then
             export CXXFLAGS="-std=c++11 -stdlib=libc++"
         fi
     fi


### PR DESCRIPTION
From ICU4C 61.1, the `using namespace icu` is removed by default.
Because of this change, php-build+ICU4C 61.1 failed to build now.

This PR fix the problem. This also fix #498.