### PR TITLE
Added -v|--verbose option for consistency with *env plugins

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -362,6 +362,10 @@ function build_package() {
 
     log "Compiling" "$source_path"
 
+    MAKE_OUTPUT='/dev/null'
+    if [ "$VERBOSE" ]; then
+        MAKE_OUTPUT='4'
+    fi
     cd "$source_path"
     {
         make $PHP_BUILD_EXTRA_MAKE_ARGUMENTS
@@ -369,7 +373,7 @@ function build_package() {
         if [ "$PHP_BUILD_KEEP_OBJECT_FILES" == "off" ]; then
             make clean
         fi
-    } > /dev/null
+    } 2>&4 1>&$MAKE_OUTPUT
     cd "$cwd"
 
     # Remove .dSYM extension from executables (OSX issue).

--- a/bin/php-build
+++ b/bin/php-build
@@ -20,7 +20,8 @@ set -e
 #/   -i|--ini <env>     php.ini to use. If <env> is a file then this file is
 #/                      used, otherwise php.ini-<env> from the source
 #/                      distribution is used. Defaults to "production".
-#/   -v|--version       Display version information and exit
+#/   -V|--version       Display version information and exit
+#/   -v|--verbose       Display compiler output to STDERR
 #/
 #
 # Usage message done like [shocco](https://github.com/rtomayko/shocco)
@@ -701,9 +702,15 @@ if [ -z $1 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     exit
 fi
 
-if [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
+if [ "$1" = "-V" ] || [ "$1" = "--version" ]; then
     display_version
     exit
+fi
+
+VERBOSE=
+if [ "$1" = "-v" ] || [ "$1" = "--verbose" ]; then
+    VERBOSE=y
+    shift 1
 fi
 
 if [ "$1" = "--definitions" ]; then
@@ -767,7 +774,11 @@ LOG_PATH="/tmp/php-build.$LOG_NAME.$TIME.log"
 
 # Redirect everything logged to STDERR (except messages by php-build itself)
 # to the Log file.
-exec 4<> "$LOG_PATH"
+if [ "$VERBOSE" ]; then
+    exec 4> >(tee $LOG_PATH)
+else
+    exec 4<> "$LOG_PATH"
+fi
 
 # Load extension plugin
 source "$PHP_BUILD_ROOT/share/php-build/extension/extension.sh"

--- a/bin/phpenv-install
+++ b/bin/phpenv-install
@@ -2,8 +2,8 @@
 #
 # Summary: Install a PHP version using the php-build plugin
 #
-# Usage: phpenv install [--ini|-i <environment>] <version>
-#        phpenv install [--ini|-i <environment>] <definition-file>
+# Usage: phpenv install [--ini|-i <environment>] [-v|--verbose] <version>
+#        phpenv install [--ini|-i <environment>] [-v|--verbose] <definition-file>
 #        phpenv install -l|--list
 #        phpenv install -V|--version
 #
@@ -21,6 +21,7 @@ set -e
 if [ "$1" = "--complete" ]; then
   echo --list
   echo --version
+  echo --verbose
   exec php-build --definitions
 fi
 
@@ -62,6 +63,11 @@ if [[ "$1" == '--ini' ]] || [[ "$1" == '-i' ]]; then
   shift 2
 fi
 
+if [[ "$1" == "--verbose" ]] || [[ "$1" = "-v" ]]; then
+  VERBOSE=--verbose
+  shift 1
+fi
+
 DEFINITION="$1"
 case "$DEFINITION" in
 "" | -* )
@@ -72,5 +78,5 @@ esac
 VERSION_NAME="${DEFINITION##*/}"
 PREFIX="${PHPENV_ROOT}/versions/${VERSION_NAME}"
 
-php-build --ini "$ENVIRONMENT" "$DEFINITION" "$PREFIX"
+php-build $VERBOSE --ini "$ENVIRONMENT" "$DEFINITION" "$PREFIX"
 phpenv rehash


### PR DESCRIPTION
This moves the --version short option of php-build from -v to -V
and replaces it with a -v|--verbose option that shows compiler output
onscreen.

This increases consistency with other rbenv-style plugins such as
rbenv/ruby-build, pyenv, nenv, goenv, etc, which all use the
-v|--verbose option.