### PR TITLE
Fix error for building PHP 5.2.17 on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ before_install:
         brew install re2c libmcrypt openssl libxml2 icu4c
         brew upgrade pkg-config
         if [[ "$DEFINITION" == "5.2.17" ]]; then
-            brew install mysql
+            brew install mysql@5.7
+            export PHP_BUILD_CONFIGURE_OPTS="$PHP_BUILD_CONFIGURE_OPTS --with-mysql=$(brew --prefix mysql@5.7) --with-mysqli=$(brew --prefix mysql@5.7)/bin/mysql_config --with-pdo-mysql=$(brew --prefix mysql@5.7)"
         fi
     fi
 


### PR DESCRIPTION
Now we cannot install homebrew `mysql` package on macOS < 10.10. So I fix to install MySQL 5.7 explicitly when building PHP 5.2.17.