### PR TITLE
Fix default language to C on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 osx_image: xcode8
+language: c
 
 os:
   - linux


### PR DESCRIPTION
We've been used Ruby as the project language on Travis CI. However, needless `rvm use default` command has been executed on each test.

This pull request fix the project language to C.