### PR TITLE
Update recommended phpenv version to madumlao/phpenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ php-build is a utility for building versions of PHP to use them side by side wit
 
 ### As `phpenv` plugin
 
-#### With CHH/[phpenv] via installer
+#### With madumlao/[phpenv] via installer
 
 It's the standard way: installs `phpenv` in $HOME/.phpenv (default
 $PHPENV_ROOT value).
 
 ```shell
-curl -L http://git.io/phpenv-installer \
+curl -L https://raw.githubusercontent.com/madumlao/phpenv-installer/master/bin/phpenv-installer \
     | bash
 ```
 
-See more on https://github.com/rogeriopradoj/phpenv-installer: install [CHH/phpenv](https://github.com/CHH/phpenv) +
+See more on https://github.com/madumlao/phpenv-installer: install [madumlao/phpenv](https://github.com/madumlao/phpenv) +
 [php-build/php-build](https://github.com/php-build/php-build) (and
 other plugins), updating all of them when you want to!
 
@@ -92,5 +92,5 @@ php-build is released under the [MIT License][license].
 [contributors]: https://github.com/php-build/php-build/graphs/contributors
 [Gittipp-ing]: https://gratipay.com/~CHH/
 [license]: LICENSE
-[phpenv]: https://github.com/CHH/phpenv
+[phpenv]: https://github.com/madumlao/phpenv
 [ruby-build]: https://github.com/rbenv/ruby-build


### PR DESCRIPTION
As discussed in #510 and #516 

> CHH/phpenv is basically a dead project. It hasn't had any update since 2014, and I'm not sure that any maintainer is still around. It works by checking out rbenv and then basically just replacing any instance of .rb -> .php. Unfortunately, sometimes in updating, this can become broken, so keeping the rbenv-* versions of the files seems like a rather simple solution for now that won't break everyone's installations.

As madumlao/phpenv is the current active branch of phpenv (phpenv/phpenv is also dead), it would seem that the best way moving forward is to recommend madumlao/phpenv in the README. Existing php-build users should be unaffected as nothing in php-build references a specific version of phpenv outside of the README, with new users being able to use the active phpenv branch.

This PR updates the README instructions so that the installer / references point to madumlao/phpenv and madumlao/phpenv-installer. Installer URL was made a bit longer, but may later be changed awaiting rogeriopradoj/phpenv-installer#1.