### PR TITLE
Populate php-fpm.conf by default using php-fpm.conf.default

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -392,6 +392,15 @@ function build_package() {
         fi
     fi
 
+    # Create php-fpm.conf from php-fpm.conf.default
+    if [ -f "$PREFIX/etc/php-fpm.conf.default" ]; then
+        cp "$PREFIX/etc/php-fpm.conf"{.default,}
+
+        if [ -f "$PREFIX/etc/php-fpm.d/www.conf.default" ]; then
+            cp "$PREFIX/etc/php-fpm.d/www.conf"{.default,}
+        fi
+    fi
+
     # Comment out 'extension_dir' in old default php.ini files (PHP 5.2). In
     # newer ones (>= 5.3) this is already the default.
     if [ -f "$PREFIX/etc/php.ini" ]; then


### PR DESCRIPTION
This allows users to just run `php-fpm` with minimal configuration
without removing the ability to configure php-fpm by editing the
conf file.