### PR TITLE
Init script

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -401,12 +401,14 @@ function build_package() {
         fi
     fi
 
+    # copy the init script
     if [ -f "$source_path/sapi/fpm/init.d.php-fpm" ]; then
         mkdir -p "$PREFIX/etc/init.d"
         cp "$source_path/sapi/fpm/init.d.php-fpm" "$PREFIX/etc/init.d/php-fpm"
         chmod +x "$PREFIX/etc/init.d/php-fpm"
     fi
 
+    # copy the systemd unit
     if [ -f "$source_path/sapi/fpm/php-fpm.service" ]; then
         mkdir -p "$PREFIX/etc/systemd/system"
         cp "$source_path/sapi/fpm/php-fpm.service" "$PREFIX/etc/systemd/system/php-fpm.service"

--- a/bin/php-build
+++ b/bin/php-build
@@ -395,6 +395,7 @@ function build_package() {
     if [ -f "$source_path/sapi/fpm/init.d.php-fpm" ]; then
         mkdir -p "$PREFIX/etc/init.d"
         cp "$source_path/sapi/fpm/init.d.php-fpm" "$PREFIX/etc/init.d/php-fpm"
+        chmod +x "$PREFIX/etc/init.d/php-fpm"
     fi
 
     if [ -f "$source_path/sapi/fpm/php-fpm.service" ]; then

--- a/bin/php-build
+++ b/bin/php-build
@@ -392,6 +392,16 @@ function build_package() {
         fi
     fi
 
+    if [ -f "$source_path/sapi/fpm/init.d.php-fpm" ]; then
+        mkdir -p "$PREFIX/etc/init.d"
+        cp "$source_path/sapi/fpm/init.d.php-fpm" "$PREFIX/etc/init.d/php-fpm"
+    fi
+
+    if [ -f "$source_path/sapi/fpm/php-fpm.service" ]; then
+        mkdir -p "$PREFIX/etc/systemd/system"
+        cp "$source_path/sapi/fpm/php-fpm.service" "$PREFIX/etc/systemd/system/php-fpm.service"
+    fi
+
     # Comment out 'extension_dir' in old default php.ini files (PHP 5.2). In
     # newer ones (>= 5.3) this is already the default.
     if [ -f "$PREFIX/etc/php.ini" ]; then


### PR DESCRIPTION
This PR copies over the init script / systemd unit generated in the PHP `make` step into the PHP prefix. This allows users to either run the `etc/init.d/php-fpm` script to start `php-fpm` or copy/install the provided `php-fpm.service` systemd unit file.

While the default provided init script / systemd unit can be used as-is, nothing stops users from writing their own init script / systemd unit.

I kinda need this to close loooong overdue https://github.com/madumlao/phpenv/issues/15

This ended up subsuming PR #528