### PR TITLE
Remove mcrypt from PHP >= 7.2

### DIFF
--- a/share/php-build/default_configure_options
+++ b/share/php-build/default_configure_options
@@ -11,7 +11,6 @@
 --enable-intl
 --with-kerberos
 --with-openssl
---with-mcrypt=/usr
 --enable-soap
 --enable-xmlreader
 --with-xsl

--- a/share/php-build/definitions/5.2.17
+++ b/share/php-build/definitions/5.2.17
@@ -1,5 +1,6 @@
 
 configure_option "--enable-fastcgi"
+configure_option "--with-mcrypt" "/usr"
 
 configure_option -R "--with-mysql"
 configure_option -R "--with-mysqli"

--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.17
+++ b/share/php-build/definitions/5.3.17
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.18
+++ b/share/php-build/definitions/5.3.18
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.19
+++ b/share/php-build/definitions/5.3.19
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"

--- a/share/php-build/definitions/5.3.20
+++ b/share/php-build/definitions/5.3.20
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.21
+++ b/share/php-build/definitions/5.3.21
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.22
+++ b/share/php-build/definitions/5.3.22
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.23
+++ b/share/php-build/definitions/5.3.23
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.24
+++ b/share/php-build/definitions/5.3.24
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.25
+++ b/share/php-build/definitions/5.3.25
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.26
+++ b/share/php-build/definitions/5.3.26
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.27
+++ b/share/php-build/definitions/5.3.27
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.28
+++ b/share/php-build/definitions/5.3.28
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.29
+++ b/share/php-build/definitions/5.3.29
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "xp_ssl.c.patch"
 patch_file "php-5.3.29-64bit-intl.patch"

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.4.0
+++ b/share/php-build/definitions/5.4.0
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.4.1
+++ b/share/php-build/definitions/5.4.1
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.4.10
+++ b/share/php-build/definitions/5.4.10
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.11
+++ b/share/php-build/definitions/5.4.11
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.12
+++ b/share/php-build/definitions/5.4.12
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.13
+++ b/share/php-build/definitions/5.4.13
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.13.tar.bz2;h=9fc012a888bc2cf7b5fb26e11eef4359c40b269f;hb=301a6d54e0efa1f0cf7b310b49ec03e17adca054"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.14
+++ b/share/php-build/definitions/5.4.14
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.14.tar.bz2;h=0d950f179d586bb1d0e879e0d4aa3a5140e8d5f5;hb=3dd2f12609fc8a730d7cf341a932f6c7b241f03c"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.15
+++ b/share/php-build/definitions/5.4.15
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.15.tar.bz2;h=a7ca6ec5c1792783158c2771f03f65c2c7312053;hb=34663c8d81e0619e23500c3d1a5c7f0d0a49905d"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.16
+++ b/share/php-build/definitions/5.4.16
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.16.tar.bz2;h=855667f60cbb30f5d28ac6aed587c3da2f587f93;hb=b3d820892c8fe64be8026c239d625536a19f7372"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.17
+++ b/share/php-build/definitions/5.4.17
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.17.tar.bz2;h=faa5b8ed7b6e154520fa09627c66b6404ca2f1be;hb=d052c0971b18b6d22b661a914a79be2da93327b5"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.18
+++ b/share/php-build/definitions/5.4.18
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.18.tar.bz2;h=17faefb906ae19191b6336135751331bee83098a;hb=512fc5d1b8622bdda0e41314b8e81d5133854caa"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.19
+++ b/share/php-build/definitions/5.4.19
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.19.tar.bz2;h=dc2babeb364e4767a1320546fced1386b867021d;hb=4c39e3c8edc074dc80077a00eab518be309a858d"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.2
+++ b/share/php-build/definitions/5.4.2
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.4.20
+++ b/share/php-build/definitions/5.4.20
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.20.tar.bz2;h=df5951b5a74997cacae7bdc205cc7f9f69c9c7ce;hb=0d30c35745d0f3ad7a4bc26f84bbcc2d1782f678"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.21
+++ b/share/php-build/definitions/5.4.21
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.21.tar.bz2;h=88f5bafb4f818ffbd9bba9d3cc835b391234ad51;hb=11e7eb77df43a899546be034a66c5679b2e0c939"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.22
+++ b/share/php-build/definitions/5.4.22
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.22.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.23
+++ b/share/php-build/definitions/5.4.23
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.23.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.24
+++ b/share/php-build/definitions/5.4.24
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.24.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.25
+++ b/share/php-build/definitions/5.4.25
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.25.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.26
+++ b/share/php-build/definitions/5.4.26
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.26.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.27
+++ b/share/php-build/definitions/5.4.27
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.27.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.28
+++ b/share/php-build/definitions/5.4.28
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.28.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.29
+++ b/share/php-build/definitions/5.4.29
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.29.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.3
+++ b/share/php-build/definitions/5.4.3
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.4.30
+++ b/share/php-build/definitions/5.4.30
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.30.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.31
+++ b/share/php-build/definitions/5.4.31
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.31.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.32
+++ b/share/php-build/definitions/5.4.32
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.32.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.33
+++ b/share/php-build/definitions/5.4.33
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.33.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.34
+++ b/share/php-build/definitions/5.4.34
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.34.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.35
+++ b/share/php-build/definitions/5.4.35
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.35.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.36
+++ b/share/php-build/definitions/5.4.36
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.36.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.37
+++ b/share/php-build/definitions/5.4.37
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.37.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.38
+++ b/share/php-build/definitions/5.4.38
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.38.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.39
+++ b/share/php-build/definitions/5.4.39
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.39.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.4
+++ b/share/php-build/definitions/5.4.4
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.4.40
+++ b/share/php-build/definitions/5.4.40
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.40.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.41
+++ b/share/php-build/definitions/5.4.41
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.41.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.42
+++ b/share/php-build/definitions/5.4.42
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.42.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.43
+++ b/share/php-build/definitions/5.4.43
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.43.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.44
+++ b/share/php-build/definitions/5.4.44
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.44.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.45
+++ b/share/php-build/definitions/5.4.45
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.4.45.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.5
+++ b/share/php-build/definitions/5.4.5
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.4.6
+++ b/share/php-build/definitions/5.4.6
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.4.7
+++ b/share/php-build/definitions/5.4.7
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.8
+++ b/share/php-build/definitions/5.4.8
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.9
+++ b/share/php-build/definitions/5.4.9
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4snapshot
+++ b/share/php-build/definitions/5.4snapshot
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package_from_github PHP-5.4
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.5.0
+++ b/share/php-build/definitions/5.5.0
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.0.tar.bz2;h=a9d7b5dbc92f9ff99fcaf911047d8c7d465160cf;hb=01253f21cc75bf10e8698d0be9a904ee4f020a99"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.1
+++ b/share/php-build/definitions/5.5.1
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.1.tar.bz2;h=7bf5067be413ff11127904468a7c308152916a80;hb=703b7b0367bb661e9d5ce2ec6f1e9f57f3418b84"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.10
+++ b/share/php-build/definitions/5.5.10
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.10.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.11
+++ b/share/php-build/definitions/5.5.11
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.11.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.12
+++ b/share/php-build/definitions/5.5.12
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.12.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.13
+++ b/share/php-build/definitions/5.5.13
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.13.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.14
+++ b/share/php-build/definitions/5.5.14
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.14.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.15
+++ b/share/php-build/definitions/5.5.15
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.15.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.16
+++ b/share/php-build/definitions/5.5.16
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.16.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.17
+++ b/share/php-build/definitions/5.5.17
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.17.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.18
+++ b/share/php-build/definitions/5.5.18
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.18.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.19
+++ b/share/php-build/definitions/5.5.19
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.19.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.2
+++ b/share/php-build/definitions/5.5.2
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.2.tar.bz2;h=ef23e90fcdc65ec8bfe2c3100780ceaf62951dde;hb=cb66297df342fd7e2e11d4c952d0793e971a3886"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.20
+++ b/share/php-build/definitions/5.5.20
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.20.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.21
+++ b/share/php-build/definitions/5.5.21
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.21.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.22
+++ b/share/php-build/definitions/5.5.22
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.22.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.23
+++ b/share/php-build/definitions/5.5.23
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.23.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.24
+++ b/share/php-build/definitions/5.5.24
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.24.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.25
+++ b/share/php-build/definitions/5.5.25
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.25.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.26
+++ b/share/php-build/definitions/5.5.26
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.26.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.27
+++ b/share/php-build/definitions/5.5.27
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.27.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.28
+++ b/share/php-build/definitions/5.5.28
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.28.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.29
+++ b/share/php-build/definitions/5.5.29
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.29.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.3
+++ b/share/php-build/definitions/5.5.3
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.3.tar.bz2;h=2f8f088ff89cb77873798a58027dcf68271f4cda;hb=4c39e3c8edc074dc80077a00eab518be309a858d"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.30
+++ b/share/php-build/definitions/5.5.30
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.30.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.31
+++ b/share/php-build/definitions/5.5.31
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.31.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.32
+++ b/share/php-build/definitions/5.5.32
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.32.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.33
+++ b/share/php-build/definitions/5.5.33
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.33.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.34
+++ b/share/php-build/definitions/5.5.34
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.34.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.35
+++ b/share/php-build/definitions/5.5.35
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.35.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.36
+++ b/share/php-build/definitions/5.5.36
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.36.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.37
+++ b/share/php-build/definitions/5.5.37
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.37.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.38
+++ b/share/php-build/definitions/5.5.38
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.38.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.4
+++ b/share/php-build/definitions/5.5.4
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.4.tar.bz2;h=6f258d1d91f812f7d7d717dba75e086b796381fd;hb=d57019e4b0bfcaa4d37288c7c7e346ed50ae04a1"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.5
+++ b/share/php-build/definitions/5.5.5
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.5.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.6
+++ b/share/php-build/definitions/5.5.6
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.6.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.7
+++ b/share/php-build/definitions/5.5.7
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.7.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.8
+++ b/share/php-build/definitions/5.5.8
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.8.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5.9
+++ b/share/php-build/definitions/5.5.9
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.5.9.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.5snapshot
+++ b/share/php-build/definitions/5.5snapshot
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package_from_github PHP-5.5
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.0
+++ b/share/php-build/definitions/5.6.0
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.0.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.1
+++ b/share/php-build/definitions/5.6.1
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.1.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.10
+++ b/share/php-build/definitions/5.6.10
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.10.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.11
+++ b/share/php-build/definitions/5.6.11
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.11.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.12
+++ b/share/php-build/definitions/5.6.12
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.12.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.13
+++ b/share/php-build/definitions/5.6.13
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.13.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.14
+++ b/share/php-build/definitions/5.6.14
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.14.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.15
+++ b/share/php-build/definitions/5.6.15
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.15.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.16
+++ b/share/php-build/definitions/5.6.16
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.16.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.17
+++ b/share/php-build/definitions/5.6.17
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.17.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.18
+++ b/share/php-build/definitions/5.6.18
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.18.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.19
+++ b/share/php-build/definitions/5.6.19
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.19.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.2
+++ b/share/php-build/definitions/5.6.2
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.2.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.20
+++ b/share/php-build/definitions/5.6.20
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.20.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.21
+++ b/share/php-build/definitions/5.6.21
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.21.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.22
+++ b/share/php-build/definitions/5.6.22
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.22.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.23
+++ b/share/php-build/definitions/5.6.23
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.23.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.24
+++ b/share/php-build/definitions/5.6.24
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.24.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.25
+++ b/share/php-build/definitions/5.6.25
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.25.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.26
+++ b/share/php-build/definitions/5.6.26
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.26.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.27
+++ b/share/php-build/definitions/5.6.27
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.27.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.28
+++ b/share/php-build/definitions/5.6.28
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.28.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.29
+++ b/share/php-build/definitions/5.6.29
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.29.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.3
+++ b/share/php-build/definitions/5.6.3
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.3.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.30
+++ b/share/php-build/definitions/5.6.30
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.30.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.31
+++ b/share/php-build/definitions/5.6.31
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.31.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.32
+++ b/share/php-build/definitions/5.6.32
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.32.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.33
+++ b/share/php-build/definitions/5.6.33
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.33.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.34
+++ b/share/php-build/definitions/5.6.34
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.34.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.35
+++ b/share/php-build/definitions/5.6.35
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.35.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.36
+++ b/share/php-build/definitions/5.6.36
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.36.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.37
+++ b/share/php-build/definitions/5.6.37
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.37.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.38
+++ b/share/php-build/definitions/5.6.38
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.38.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.4
+++ b/share/php-build/definitions/5.6.4
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.4.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.5
+++ b/share/php-build/definitions/5.6.5
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.5.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.6
+++ b/share/php-build/definitions/5.6.6
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.6.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.7
+++ b/share/php-build/definitions/5.6.7
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.7.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.8
+++ b/share/php-build/definitions/5.6.8
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.8.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6.9
+++ b/share/php-build/definitions/5.6.9
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package "https://secure.php.net/distributions/php-5.6.9.tar.bz2"
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/5.6snapshot
+++ b/share/php-build/definitions/5.6snapshot
@@ -1,4 +1,5 @@
 configure_option "--with-mysql" "mysqlnd"
+configure_option "--with-mcrypt" "/usr"
 
 install_package_from_github PHP-5.6
 install_xdebug "2.5.5"

--- a/share/php-build/definitions/7.0.0
+++ b/share/php-build/definitions/7.0.0
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.0.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.1
+++ b/share/php-build/definitions/7.0.1
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.1.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.10
+++ b/share/php-build/definitions/7.0.10
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.10.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.11
+++ b/share/php-build/definitions/7.0.11
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.11.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.12
+++ b/share/php-build/definitions/7.0.12
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.12.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.13
+++ b/share/php-build/definitions/7.0.13
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.13.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.14
+++ b/share/php-build/definitions/7.0.14
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.14.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.15
+++ b/share/php-build/definitions/7.0.15
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.15.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.16
+++ b/share/php-build/definitions/7.0.16
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.16.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.17
+++ b/share/php-build/definitions/7.0.17
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.17.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.18
+++ b/share/php-build/definitions/7.0.18
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.18.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.19
+++ b/share/php-build/definitions/7.0.19
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.19.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.2
+++ b/share/php-build/definitions/7.0.2
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.2.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.20
+++ b/share/php-build/definitions/7.0.20
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.20.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.21
+++ b/share/php-build/definitions/7.0.21
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.21.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.22
+++ b/share/php-build/definitions/7.0.22
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.22.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.23
+++ b/share/php-build/definitions/7.0.23
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.23.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.24
+++ b/share/php-build/definitions/7.0.24
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.24.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.25
+++ b/share/php-build/definitions/7.0.25
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.25.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.26
+++ b/share/php-build/definitions/7.0.26
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.26.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.27
+++ b/share/php-build/definitions/7.0.27
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.27.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.28
+++ b/share/php-build/definitions/7.0.28
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.28.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.29
+++ b/share/php-build/definitions/7.0.29
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.29.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.3
+++ b/share/php-build/definitions/7.0.3
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.3.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.30
+++ b/share/php-build/definitions/7.0.30
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.30.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.31
+++ b/share/php-build/definitions/7.0.31
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.31.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.32
+++ b/share/php-build/definitions/7.0.32
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.32.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.4
+++ b/share/php-build/definitions/7.0.4
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.4.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.5
+++ b/share/php-build/definitions/7.0.5
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.5.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.6
+++ b/share/php-build/definitions/7.0.6
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.6.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.7
+++ b/share/php-build/definitions/7.0.7
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.7.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.8
+++ b/share/php-build/definitions/7.0.8
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.8.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0.9
+++ b/share/php-build/definitions/7.0.9
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.0.9.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.0snapshot
+++ b/share/php-build/definitions/7.0snapshot
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package_from_github PHP-7.0
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.0
+++ b/share/php-build/definitions/7.1.0
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.0.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.1
+++ b/share/php-build/definitions/7.1.1
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.1.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.10
+++ b/share/php-build/definitions/7.1.10
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.10.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.11
+++ b/share/php-build/definitions/7.1.11
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.11.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.12
+++ b/share/php-build/definitions/7.1.12
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.12.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.13
+++ b/share/php-build/definitions/7.1.13
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.13.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.14
+++ b/share/php-build/definitions/7.1.14
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.14.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.15
+++ b/share/php-build/definitions/7.1.15
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.15.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.16
+++ b/share/php-build/definitions/7.1.16
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.16.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.17
+++ b/share/php-build/definitions/7.1.17
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.17.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.18
+++ b/share/php-build/definitions/7.1.18
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.18.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.19
+++ b/share/php-build/definitions/7.1.19
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.19.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.2
+++ b/share/php-build/definitions/7.1.2
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.2.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.20
+++ b/share/php-build/definitions/7.1.20
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.20.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.21
+++ b/share/php-build/definitions/7.1.21
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.21.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.22
+++ b/share/php-build/definitions/7.1.22
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.22.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.23
+++ b/share/php-build/definitions/7.1.23
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.23.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.3
+++ b/share/php-build/definitions/7.1.3
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.3.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.4
+++ b/share/php-build/definitions/7.1.4
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.4.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.5
+++ b/share/php-build/definitions/7.1.5
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.5.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.6
+++ b/share/php-build/definitions/7.1.6
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.6.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.7
+++ b/share/php-build/definitions/7.1.7
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.7.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.8
+++ b/share/php-build/definitions/7.1.8
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.8.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1.9
+++ b/share/php-build/definitions/7.1.9
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package "https://secure.php.net/distributions/php-7.1.9.tar.bz2"
 install_xdebug "2.6.1"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.1snapshot
+++ b/share/php-build/definitions/7.1snapshot
@@ -1,3 +1,5 @@
+configure_option "--with-mcrypt" "/usr"
+
 install_package_from_github PHP-7.1
 install_xdebug "2.6.1"
 enable_builtin_opcache


### PR DESCRIPTION
Mcrypt moved to PECL from PHP 7.2.
So, configure by php-build for PHP 7.2.x reports `WARNING: unrecognized options: --with-mcrypt` now.

See also: http://php.net/manual/en/migration72.other-changes.php#migration72.other-changes.mcrypt