### PR TITLE
Only copy over php-related executables in bin during install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ echo " done."
 
 echo -n "  - copying files..."
 
-cp -r "$DIR/bin/php*" "$PREFIX/bin"
+cp -r "$DIR/bin/php"* "$PREFIX/bin"
 cp -r "$DIR/share" "$PREFIX/"
 cp "$DIR/man/php-build.1" "$MAN_DIR/man1/"
 cp "$DIR/man/php-build.5" "$MAN_DIR/man5/"

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,8 @@ echo " done."
 
 echo -n "  - copying files..."
 
-cp -r "$DIR/"{bin,share} "$PREFIX/"
+cp -r "$DIR/bin/php*" "$PREFIX/bin"
+cp -r "$DIR/share" "$PREFIX/"
 cp "$DIR/man/php-build.1" "$MAN_DIR/man1/"
 cp "$DIR/man/php-build.5" "$MAN_DIR/man5/"
 


### PR DESCRIPTION
This is needed so that it won't interfere with ruby-build if installed
using install.sh, such as, for example, if installed using homebrew.

A homebrew formula is currently in development :)