### PR TITLE
Add patch mode for configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
       - libzip-dev
       - php5-cli
       - re2c
+    update: true
 
 env:
   global:
@@ -34,9 +35,14 @@ env:
 
 before_install:
   - |
-    if [[ "$TRAVIS_OS_NAME" == "linux" &&
-          "$DEFINITION" =~ ^("5.2.".*|"5.3."[0-6])$ ]]; then
-        export PHP_BUILD_CONFIGURE_OPTS="--with-libdir=lib/x86_64-linux-gnu"
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        if [[ "$DEFINITION" =~ ^("5.2.".*|"5.3."[0-6])$ ]]; then
+            export PHP_BUILD_CONFIGURE_OPTS="--with-libdir=lib/x86_64-linux-gnu"
+        fi
+        if [[ "$DEFINITION" =~ ^("5.2.".*|"5.3.".*)$ ]]; then
+            sudo apt-get install -y autoconf2.13
+            export PHP_AUTOCONF=/usr/bin/autoconf2.13
+        fi
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -49,6 +55,10 @@ before_install:
         if [[ "$DEFINITION" == "5.2.17" ]]; then
             brew install mysql@5.7
             export PHP_BUILD_CONFIGURE_OPTS="$PHP_BUILD_CONFIGURE_OPTS --with-mysql=$(brew --prefix mysql@5.7) --with-mysqli=$(brew --prefix mysql@5.7)/bin/mysql_config --with-pdo-mysql=$(brew --prefix mysql@5.7)"
+        fi
+        if [[ "$DEFINITION" =~ ^("5.2.".*|"5.3.".*)$ ]]; then
+            brew install autoconf@2.13
+            export PHP_AUTOCONF=$(brew --prefix autoconf@2.13)/bin/autoconf213
         fi
     fi
 

--- a/bin/php-build
+++ b/bin/php-build
@@ -220,9 +220,14 @@ function download() {
     local package_file="$PHP_BUILD_TMPDIR/packages/$basename"
     local archive_type=$2
     local temp_package="$PHP_BUILD_TMPDIR/$basename"
+    local package_name=$(definition_package_name)
 
-    if [ -z $archive_type ]; then
+    if [ -z "$archive_type" ]; then
         archive_type=${package_file##*.}
+    fi
+
+    if has_patch $package_name; then
+        rm -rf "$PHP_BUILD_TMPDIR/source/$DEFINITION"
     fi
 
     if [ -d "$PHP_BUILD_TMPDIR/source/$DEFINITION" ]; then
@@ -344,7 +349,8 @@ function load_plugins() {
 function build_package() {
     local source_path=$1
     local cwd="$(pwd)"
-    if [ -z $1 ]; then
+
+    if [ -z "$source_path" ]; then
       local source_path="$PHP_BUILD_TMPDIR/source/$DEFINITION"
     fi
 
@@ -471,6 +477,20 @@ function install_package() {
     } >&4 2>&1
 }
 
+function is_php_package() {
+    local package_name=$1
+
+    case "$package_name" in
+    php-* ) return 0 ;;
+    esac
+
+    return 1
+}
+
+function definition_package_name() {
+    echo "php-$DEFINITION"
+}
+
 # ### configure_option
 #
 # This function sets and unsets arguments for `configure`. Pass it
@@ -531,6 +551,16 @@ function patch_file() {
     fi
 }
 
+function has_patch() {
+    local package_name=$1
+
+    if is_php_package $package_name; then
+        [ -n "$PATCH_FILES" ]
+    else
+        return 1
+    fi
+}
+
 # ### with_openssl
 #
 # Configures PHP with OpenSSL support.
@@ -563,10 +593,13 @@ function with_apxs2() {
 function configure_package() {
     local source_path=$1
     local backup_pwd=$(pwd)
+    local package_name="$(definition_package_name)"
 
     cd "$source_path"
 
-    if [ ! -f ./configure ]; then
+    if has_patch $package_name; then
+        ./buildconf --force
+    elif [ ! -f ./configure ]; then
         ./buildconf
     fi
 

--- a/bin/php-build
+++ b/bin/php-build
@@ -368,7 +368,7 @@ function build_package() {
 
     MAKE_OUTPUT='/dev/null'
     if [ "$VERBOSE" ]; then
-        MAKE_OUTPUT='4'
+        MAKE_OUTPUT='&4'
     fi
     cd "$source_path"
     {
@@ -377,7 +377,7 @@ function build_package() {
         if [ "$PHP_BUILD_KEEP_OBJECT_FILES" == "off" ]; then
             make clean
         fi
-    } 2>&4 1>&$MAKE_OUTPUT
+    } 2>&4 1>$MAKE_OUTPUT
     cd "$cwd"
 
     # Remove .dSYM extension from executables (OSX issue).
@@ -595,13 +595,20 @@ function configure_package() {
     local backup_pwd=$(pwd)
     local package_name="$(definition_package_name)"
 
+    CONFIGURE_OUTPUT='/dev/null'
+    if [ "$VERBOSE" ]; then
+        CONFIGURE_OUTPUT='&4'
+    fi
+
     cd "$source_path"
 
-    if has_patch $package_name; then
-        ./buildconf --force
-    elif [ ! -f ./configure ]; then
-        ./buildconf
-    fi
+    {
+        if has_patch $package_name; then
+            buildconf_wrapper --force
+        elif [ ! -f ./configure ]; then
+            buildconf_wrapper
+        fi
+    } 1>$CONFIGURE_OUTPUT
 
     # Mac OSX stores some libraries (for example `libpng`)
     # in `/usr/X11/lib` instead of `/usr/lib`.
@@ -678,7 +685,7 @@ $CONFIGURE_OPTIONS"
         export ac_cv_exeext=''
     fi
 
-    ./configure $argv > /dev/null
+    ./configure $argv 1>$CONFIGURE_OUTPUT
 
     # Use php-build prefix for the Apache libexec folder
     if [ -n "$PHP_BUILD_APXS" ]; then
@@ -687,6 +694,26 @@ $CONFIGURE_OPTIONS"
     fi
 
     cd "$backup_pwd"
+}
+
+function buildconf_wrapper() {
+    local buildconf_log_path="$(mktemp "${PHP_BUILD_TMPDIR}/buildconf_XXXXXX.log")"
+    local result
+
+    set +e
+    ./buildconf "$@" >$buildconf_log_path
+    result=$?
+    set -e
+
+    if [ $result -eq 0 ]; then
+        cat $buildconf_log_path
+    else
+        echo "Failed to run 'buildconf'." 1>&2
+        cat $buildconf_log_path 1>&2
+    fi
+    rm -f $buildconf_log_path
+
+    return $result
 }
 
 # Handles build errors, and displays the last 10 lines of the build log
@@ -835,7 +862,6 @@ LOG_NAME="$(basename "$DEFINITION_PATH")"
 # Generate the Path for the build log.
 TIME="$(date "+%Y%m%d%H%M%S")"
 LOG_PATH="/tmp/php-build.$LOG_NAME.$TIME.log"
-log Info "Appending build output to $LOG_PATH"
 
 # Redirect everything logged to STDERR (except messages by php-build itself)
 # to the Log file.
@@ -876,10 +902,12 @@ trap - ERR
 trap - EXIT
 
 # Display a notice if build warnings got logged.
-if [ -n $LOG_PATH ]; then
+if [ -n "$LOG_PATH" ] && [ -n "$(head -100 $LOG_PATH)" ]; then
     log "Info" "The Log File is not empty, but the Build did not fail.\
  Maybe just warnings got logged.\
- You can review the log in $LOG_PATH"
+ You can review the log in $LOG_PATH or rebuild with '--verbose' option"
+elif [ -f "$LOG_PATH" ]; then
+    rm -rf "$LOG_PATH"
 fi
 
 log "Success" "Built $DEFINITION successfully."

--- a/share/php-build/definitions/5.3.29
+++ b/share/php-build/definitions/5.3.29
@@ -2,7 +2,6 @@ configure_option "--with-mysql" "mysqlnd"
 
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
-patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://secure.php.net/distributions/php-5.3.29.tar.bz2"
 install_xdebug "2.2.7"

--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -141,17 +141,22 @@ function _build_extension {
     local after_install=$6
     local cwd=$(pwd)
 
+    BUILD_EXTENSION_OUTPUT='/dev/null'
+    if [ "$VERBOSE" ]; then
+        BUILD_EXTENSION_OUTPUT='&4'
+    fi
+
     log "$name" "Compiling $name in $source_dir"
 
     cd "$source_dir/$source_cwd"
 
     {
-        $PREFIX/bin/phpize 1>&2
+        $PREFIX/bin/phpize 1>$BUILD_EXTENSION_OUTPUT
         "$(pwd)/configure" --with-php-config=$PREFIX/bin/php-config \
-            $configure_args > /dev/null
+            $configure_args 1>$BUILD_EXTENSION_OUTPUT
 
-        make > /dev/null
-        make install > /dev/null
+        make 1>$BUILD_EXTENSION_OUTPUT
+        make install 1>$BUILD_EXTENSION_OUTPUT
     } >&4 2>&1
 
     local extension_home="$PREFIX/share/$name"


### PR DESCRIPTION
Because current PHP archive includes `configure`:

```
$ tar tf /var/tmp/php-build/packages/php-7.2.9.tar.bz2 | grep configure
php-7.2.9/configure
php-7.2.9/Zend/configure.ac
php-7.2.9/configure.ac
php-7.2.9/TSRM/configure.ac
php-7.2.9/win32/build/configure.bat
php-7.2.9/win32/build/configure.tail
php-7.2.9/ext/mbstring/libmbfl/configure.ac
php-7.2.9/ext/bcmath/libbcmath/configure
php-7.2.9/ext/bcmath/libbcmath/configure.ac
```

, we should restore source and run `buildconf` to apply patches.

And, I improved outputs.