### PR TITLE
Issue #562: Remove v5.2.17 from travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ env:
   global:
     - PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j2"
   matrix:
-    - DEFINITION=5.2.17
     - DEFINITION=5.3.29
     - DEFINITION=5.4.45
     - DEFINITION=5.5.38


### PR DESCRIPTION
Since 5.2.17 does not build on Mac, remove it to get an overall green build again.