### PR TITLE
Generic PECL Extension Installer

### DIFF
--- a/share/php-build/extension/definition
+++ b/share/php-build/extension/definition
@@ -1,5 +1,9 @@
 "name","url-dist","url_source","source_cwd","configure_args","extension_type","after_install"
 "apc","http://pecl.php.net/get/APC-$version.tgz","git@git.php.net:/pecl/caching/apc.git",,"--enable-apc","extension",
+"apcu","http://pecl.php.net/get/apcu-$version.tgz","https://github.com/krakjoe/apcu.git",,,"extension",
+"igbinary","http://pecl.php.net/get/igbinary-$version.tgz","https://github.com/igbinary/igbinary.git",,,"extension",
+"imagick","http://pecl.php.net/get/imagick-$version.tgz","https://github.com/mkoppanen/imagick.git",,,"extension",
+"memcache","http://pecl.php.net/get/memcache-$version.tgz","git@git.php.net:/pecl/caching/memcache.git",,,"extension",
 "memcached","http://pecl.php.net/get/memcached-$version.tgz","https://github.com/php-memcached-dev/php-memcached.git",,"--disable-memcached-sasl","extension",
 "uprofiler",,"https://github.com/FriendsOfPHP/uprofiler.git","extension",,"extension","uprofiler_after_install"
 "xcache","http://xcache.lighttpd.net/pub/Releases/$version/xcache-$version.tar.gz",,,"--enable-xcache","extension",

--- a/share/php-build/extension/definition
+++ b/share/php-build/extension/definition
@@ -1,9 +1,5 @@
 "name","url-dist","url_source","source_cwd","configure_args","extension_type","after_install"
 "apc","http://pecl.php.net/get/APC-$version.tgz","git@git.php.net:/pecl/caching/apc.git",,"--enable-apc","extension",
-"apcu","http://pecl.php.net/get/apcu-$version.tgz","https://github.com/krakjoe/apcu.git",,,"extension",
-"igbinary","http://pecl.php.net/get/igbinary-$version.tgz","https://github.com/igbinary/igbinary.git",,,"extension",
-"imagick","http://pecl.php.net/get/imagick-$version.tgz","https://github.com/mkoppanen/imagick.git",,,"extension",
-"memcache","http://pecl.php.net/get/memcache-$version.tgz","git@git.php.net:/pecl/caching/memcache.git",,,"extension",
 "memcached","http://pecl.php.net/get/memcached-$version.tgz","https://github.com/php-memcached-dev/php-memcached.git",,"--disable-memcached-sasl","extension",
 "uprofiler",,"https://github.com/FriendsOfPHP/uprofiler.git","extension",,"extension","uprofiler_after_install"
 "xcache","http://xcache.lighttpd.net/pub/Releases/$version/xcache-$version.tar.gz",,,"--enable-xcache","extension",

--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -39,7 +39,9 @@ function install_extension {
                 "$configure_args" $extension_type "$after_install"
         fi
     else
-        echo "No configuration found for extension \"$extension\", skipping" >&3
+        log "$extension" "No definition found, assuming default PECL installation"
+
+        _download_extension $extension $version "http://pecl.php.net/get/$extension-$version.tgz" "" "extension" ""
     fi
 }
 


### PR DESCRIPTION
If there is no definition for an extension attempt to download the extension from PECL, rather than just skipping it. In theory this opens up many more extensions to be installed (tried with `yaml` and `redis`).

I also deleted a handful of definitions that didn't add any additional configuration beyond the default. This *does* eliminate the ability to install these extensions from source. If that's deemed an important feature, it should be easy enough to add them back.