### PR TITLE
Removed macos 5.2 build from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,11 +76,6 @@ matrix:
         - PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j2"
         - DEFINITION=7.3.11
     - os: osx
-      osx_image: xcode8
-      env:
-        - PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j2"
-        - DEFINITION=5.2.17
-    - os: osx
       osx_image: xcode9.4
       env:
         - PHP_BUILD_EXTRA_MAKE_ARGUMENTS="-j2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,10 +132,7 @@ before_install:
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        if [[ "$DEFINITION" == "5.2.17" ]]; then
-            export PHP_BUILD_CONFIGURE_OPTS="--without-mysql --without-mysqli --without-pdo-mysql"
-        fi
-        if [[ "$DEFINITION" =~ ^("5.2.".*|"5.3.".*)$ ]]; then
+        if [[ "$DEFINITION" =~ ^("5.3.".*)$ ]]; then
             brew install autoconf@2.13
             export PHP_AUTOCONF=$(brew --prefix autoconf@2.13)/bin/autoconf213
             export LIBS="-lssl -lcrypto"


### PR DESCRIPTION
Travis is too slow to run this build. Who even uses PHP 5.2 these days anyway? I think it's enough for us to keep the Linux tests.