### PR TITLE
Disable travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: c
 
-cache:
-  apt: true
-  directories:
-    - $HOME/Library/Caches/Homebrew
-
 addons:
   apt:
     sources:


### PR DESCRIPTION
Looks like cache setup and teardown is taking around 4 minutes on osx. Is this slower than not having it... after travis builds this PR, we will find out.