### PR TITLE
Check out the desired branch before resetting

### DIFF
--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -126,6 +126,7 @@ function _checkout_extension {
     if [ -n "$revision" ]; then
         log "$name" "Checkout specified revision: $revision"
         cd "$source_dir"
+        git checkout $revision
         git reset --hard $revision
         cd "$cwd"
     fi


### PR DESCRIPTION
Without it, `git` may complain:

    fatal: ambiguous argument 'xdebug_2_9': unknown revision or path not in the working tree.

See https://travis-ci.com/github/travis-ci/php-src-builder/jobs/329771951#L3462 for an example of this failure.