### PR TITLE
Set make jobs to number of CPUs

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -92,6 +92,24 @@ function osx_minor {
     return 0
 }
 
+num_cpu_cores() {
+    local num
+    case "$(uname -s)" in
+    Darwin | *BSD )
+        num="$(sysctl -n hw.ncpu 2>/dev/null || true)"
+        ;;
+    SunOS )
+        num="$(getconf NPROCESSORS_ONLN 2>/dev/null || true)"
+        ;;
+    * )
+        num="$({ getconf _NPROCESSORS_ONLN ||
+             grep -c ^processor /proc/cpuinfo; } 2>/dev/null)"
+        num="${num#0}"
+        ;;
+    esac
+    echo "${num:-2}"
+}
+
 # Common Variables
 # ----------------
 
@@ -375,7 +393,7 @@ function build_package() {
     fi
     cd "$source_path"
     {
-        make $PHP_BUILD_EXTRA_MAKE_ARGUMENTS
+        make -j $(num_cpu_cores) $PHP_BUILD_EXTRA_MAKE_ARGUMENTS
         make install
         if [ "$PHP_BUILD_KEEP_OBJECT_FILES" == "off" ]; then
             make clean


### PR DESCRIPTION
This change is imported from rbenv, originally the work of:

- Mislav Marohnić @mislav: https://github.com/rbenv/ruby-build/commit/6c08c56d3aa0add92c60653744324e7cdb3b24c3 https://github.com/rbenv/ruby-build/commit/f4c2fe67e3b8f2f2304ce75beaa54bc5b3cb5371
- Kjetil Limkjær @klimkjar: https://github.com/rbenv/ruby-build/commit/6d6725a8a26ac6be8bdd1fbf97f96efa296d90e5
- Ville Skyttä @scop: https://github.com/rbenv/ruby-build/commit/67c47603ee4cd86550bf0a0069a0a45b02057c7c