### PR TITLE
Add curl detection patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: ci
+on:
+  pull_request:
+  push:
+jobs:
+  test-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - 'centos:7'
+          - 'centos:8'
+          - 'ubuntu:18.04'
+          - 'ubuntu:20.04'
+        php:
+          - '5.2.17'
+          - '5.3.29'
+          - '5.4.45'
+          - '5.5.38'
+          - '5.6.40'
+          - '7.0.33'
+          - '7.1.33'
+          - '7.2.33'
+          - '7.3.22'
+          - '7.4.10'
+        exclude:
+          # TODO: libmysqlclient-dev dependency
+          - { distro: 'centos:7', php: '5.2.17'}
+          # TODO: libmysqlclient-dev dependency & curl-config
+          - { distro: 'centos:8', php: '5.2.17'}
+          - { distro: 'ubuntu:18.04', php: '5.2.17'}
+          - { distro: 'ubuntu:20.04', php: '5.2.17'}
+          # TODO: curl-config
+          - { distro: 'ubuntu:18.04', php: '5.3.29'}
+          - { distro: 'ubuntu:18.04', php: '5.4.45'}
+          - { distro: 'ubuntu:18.04', php: '5.5.38'}
+          - { distro: 'ubuntu:18.04', php: '5.6.40'}
+          - { distro: 'ubuntu:20.04', php: '5.3.29'}
+          - { distro: 'ubuntu:20.04', php: '5.4.45'}
+          - { distro: 'ubuntu:20.04', php: '5.5.38'}
+          - { distro: 'ubuntu:20.04', php: '5.6.40'}
+          # TODO: icu-config / intl
+          - { distro: 'ubuntu:20.04', php: '7.0.33'}
+          # TODO: openssl 1.0.2
+          - { distro: 'centos:8', php: '5.3.29'}
+          - { distro: 'centos:8', php: '5.4.45'}
+          - { distro: 'centos:8', php: '5.5.38'}
+          # libzip (0.10.1) on CentOS 7 is too old for PHP 7.3+ (required: >= 0.11)
+          - { distro: 'centos:7', php: '7.3.22'}
+          - { distro: 'centos:7', php: '7.4.10'}
+    name: "test (php-${{ matrix.php }}, ${{ matrix.distro }})"
+    container: "${{ matrix.distro }}"
+    env:
+      # https://bugs.php.net/bug.php?id=79445
+      PHP_BUILD_CURL_OPTS: '--retry 3 --retry-delay 5 --connect-timeout 10'
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          set -ex
+          ./install-dependencies.sh
+          git clone --depth 1 https://github.com/sstephenson/bats.git
+          ./bats/install.sh /usr/local
+      - name: run tests
+        run: |
+          set -ex
+          if ! ./run-tests.sh ${{ matrix.php }}; then
+            cat /tmp/php-build.*.log
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
     env:
       # https://bugs.php.net/bug.php?id=79445
       PHP_BUILD_CURL_OPTS: '--retry 3 --retry-delay 5 --connect-timeout 10'
+      # Fail if php-build is using unrecognized configure options by default.
+      PHP_BUILD_CONFIGURE_OPTS: '--enable-option-checking=fatal'
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,11 @@ jobs:
           - { distro: 'centos:8', php: '5.2.17'}
           - { distro: 'ubuntu:18.04', php: '5.2.17'}
           - { distro: 'ubuntu:20.04', php: '5.2.17'}
-          # TODO: curl-config
-          - { distro: 'ubuntu:18.04', php: '5.3.29'}
-          - { distro: 'ubuntu:18.04', php: '5.4.45'}
-          - { distro: 'ubuntu:18.04', php: '5.5.38'}
-          - { distro: 'ubuntu:18.04', php: '5.6.40'}
+          # TODO: icu-config / intl
           - { distro: 'ubuntu:20.04', php: '5.3.29'}
           - { distro: 'ubuntu:20.04', php: '5.4.45'}
           - { distro: 'ubuntu:20.04', php: '5.5.38'}
           - { distro: 'ubuntu:20.04', php: '5.6.40'}
-          # TODO: icu-config / intl
           - { distro: 'ubuntu:20.04', php: '7.0.33'}
           # libzip (0.10.1) on CentOS 7 is too old for PHP 7.3+ (required: >= 0.11)
           - { distro: 'centos:7', php: '7.3.22'}
@@ -49,6 +44,9 @@ jobs:
           - { distro: 'centos:8', php: '5.3.29', openssl102: true}
           - { distro: 'centos:8', php: '5.4.45', openssl102: true}
           - { distro: 'centos:8', php: '5.5.38', openssl102: true}
+          - { distro: 'ubuntu:18.04', php: '5.3.29', openssl102: true}
+          - { distro: 'ubuntu:18.04', php: '5.4.45', openssl102: true}
+          - { distro: 'ubuntu:18.04', php: '5.5.38', openssl102: true}
     name: "test (php-${{ matrix.php }}, ${{ matrix.distro }})"
     container: "${{ matrix.distro }}"
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,13 @@ jobs:
           - { distro: 'ubuntu:20.04', php: '5.6.40'}
           # TODO: icu-config / intl
           - { distro: 'ubuntu:20.04', php: '7.0.33'}
-          # TODO: openssl 1.0.2
-          - { distro: 'centos:8', php: '5.3.29'}
-          - { distro: 'centos:8', php: '5.4.45'}
-          - { distro: 'centos:8', php: '5.5.38'}
           # libzip (0.10.1) on CentOS 7 is too old for PHP 7.3+ (required: >= 0.11)
           - { distro: 'centos:7', php: '7.3.22'}
           - { distro: 'centos:7', php: '7.4.10'}
+        include:
+          - { distro: 'centos:8', php: '5.3.29', openssl102: true}
+          - { distro: 'centos:8', php: '5.4.45', openssl102: true}
+          - { distro: 'centos:8', php: '5.5.38', openssl102: true}
     name: "test (php-${{ matrix.php }}, ${{ matrix.distro }})"
     container: "${{ matrix.distro }}"
     env:
@@ -62,9 +62,15 @@ jobs:
           ./install-dependencies.sh
           git clone --depth 1 https://github.com/sstephenson/bats.git
           ./bats/install.sh /usr/local
+          if [ "${{ matrix.openssl102 }}" = "true" ]; then
+            ./build-openssl-1.0.sh
+          fi
       - name: run tests
         run: |
           set -ex
+          if [ "${{ matrix.openssl102 }}" = "true" ]; then
+            export PHP_BUILD_CONFIGURE_OPTS="$PHP_BUILD_CONFIGURE_OPTS --with-openssl=/usr/local/opt/openssl@1.0"
+          fi
           if ! ./run-tests.sh ${{ matrix.php }}; then
             cat /tmp/php-build.*.log
             exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,28 +42,28 @@ matrix:
       dist: xenial
       env: DEFINITION=8.0snapshot
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       env: DEFINITION=5.5.38
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       env: DEFINITION=5.6.40
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode11.3
       env: DEFINITION=7.0.33
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode11.3
       env: DEFINITION=7.1.33
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode11.3
       env: DEFINITION=7.2.33
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode11.3
       env: DEFINITION=7.3.22
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode11.3
       env: DEFINITION=7.4.10
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode11.3
       env: DEFINITION=8.0snapshot
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,7 @@ install:
   - bats --version
 
 script:
+  - export PHP_BUILD_CONFIGURE_OPTS="$PHP_BUILD_CONFIGURE_OPTS$PHP_BUILD_CONFIGURE_OPTS --enable-option-checking=fatal"
   - ./run-tests.sh $DEFINITION
 
 after_failure:

--- a/bin/php-build
+++ b/bin/php-build
@@ -695,14 +695,14 @@ function configure_package() {
         log "Warning" "Enabling Zend Thread Safety is meant only for maintainers!"
     fi
 
-    if [[ $phpLower74 ]] && is_osx && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix libxml2)" ]; then
-        configure_option -R "--with-libxml-dir" "$(brew --prefix libxml2)"
+    if is_osx && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix bzip2)" ]; then
+        # macOS 10.13 works with stock bzip2, but in later versions ./configure
+        # will not find it. Homebrew version works with 10.13 and higher.
+        configure_option -R "--with-bz2" "$(brew --prefix bzip2)"
     fi
 
-    if is_osx && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix openssl)" ]; then
-        # openssl 1.1 on macOS requires using pkg-config (or patching)
-        export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}$(brew --prefix openssl)/lib/pkgconfig"
-        configure_option -R "--with-openssl" "$(brew --prefix openssl)"
+    if is_osx && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix libiconv)" ]; then
+        configure_option -R "--with-iconv" "$(brew --prefix libiconv)"
     fi
 
     if is_osx && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix icu4c)" ]; then
@@ -718,6 +718,20 @@ function configure_package() {
         elif [[ -z "$CXXFLAGS" && $($(brew --prefix icu4c)/bin/icu-config --version) > "59" ]]; then
             export CXXFLAGS="-std=c++11 -stdlib=libc++"
         fi
+    fi
+
+    if [[ $phpLower74 ]] && is_osx && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix libxml2)" ]; then
+        configure_option -R "--with-libxml-dir" "$(brew --prefix libxml2)"
+    fi
+
+    if is_osx && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix openssl)" ]; then
+        # openssl 1.1 on macOS requires using pkg-config (or patching)
+        export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}$(brew --prefix openssl)/lib/pkgconfig"
+        configure_option -R "--with-openssl" "$(brew --prefix openssl)"
+    fi
+
+    if is_osx && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix zlib)" ]; then
+        configure_option -R "--with-zlib" "$(brew --prefix zlib)"
     fi
 
     CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $PHP_BUILD_CONFIGURE_OPTS $CONFIGURE_OPTS"

--- a/bin/php-build
+++ b/bin/php-build
@@ -663,6 +663,11 @@ function configure_package() {
 
     {
         if has_patch $package_name; then
+            if [ -f ./configure.in ]; then
+                # Even if a patch touches ext/*/config.m4, ./buildconf may not
+                # re-generate ./configure (e.g. PHP 5.3 + Ubuntu 18.04).
+                touch configure.in
+	    fi
             buildconf_wrapper --force
         elif [ ! -f ./configure ]; then
             buildconf_wrapper

--- a/share/php-build/default_configure_options
+++ b/share/php-build/default_configure_options
@@ -10,7 +10,7 @@
 --with-xsl
 --enable-ftp
 --enable-cgi
---with-curl=/usr
+--with-curl
 --with-tidy
 --with-xmlrpc
 --enable-sysvsem

--- a/share/php-build/definitions/5.2.17
+++ b/share/php-build/definitions/5.2.17
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--enable-fastcgi"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.17
+++ b/share/php-build/definitions/5.3.17
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.17
+++ b/share/php-build/definitions/5.3.17
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.18
+++ b/share/php-build/definitions/5.3.18
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.18
+++ b/share/php-build/definitions/5.3.18
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.19
+++ b/share/php-build/definitions/5.3.19
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.19
+++ b/share/php-build/definitions/5.3.19
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
 patch_file "php-5.3.29-64bit-intl.patch"

--- a/share/php-build/definitions/5.3.20
+++ b/share/php-build/definitions/5.3.20
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.20
+++ b/share/php-build/definitions/5.3.20
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.21
+++ b/share/php-build/definitions/5.3.21
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.21
+++ b/share/php-build/definitions/5.3.21
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.22
+++ b/share/php-build/definitions/5.3.22
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.22
+++ b/share/php-build/definitions/5.3.22
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.23
+++ b/share/php-build/definitions/5.3.23
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.23
+++ b/share/php-build/definitions/5.3.23
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.24
+++ b/share/php-build/definitions/5.3.24
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.24
+++ b/share/php-build/definitions/5.3.24
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.25
+++ b/share/php-build/definitions/5.3.25
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.25
+++ b/share/php-build/definitions/5.3.25
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.26
+++ b/share/php-build/definitions/5.3.26
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.26
+++ b/share/php-build/definitions/5.3.26
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.27
+++ b/share/php-build/definitions/5.3.27
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.27
+++ b/share/php-build/definitions/5.3.27
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.28
+++ b/share/php-build/definitions/5.3.28
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.28
+++ b/share/php-build/definitions/5.3.28
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.29
+++ b/share/php-build/definitions/5.3.29
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.3.29
+++ b/share/php-build/definitions/5.3.29
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "xp_ssl.c.patch"
 patch_file "zip_direct.c.patch"
 patch_file "php-5.3.29-64bit-intl.patch"

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "xp_ssl.c.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -1,4 +1,5 @@
 autoconf_version 2.13
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.3.29-64bit-intl.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"

--- a/share/php-build/definitions/5.4.0
+++ b/share/php-build/definitions/5.4.0
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.0
+++ b/share/php-build/definitions/5.4.0
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.1
+++ b/share/php-build/definitions/5.4.1
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.1
+++ b/share/php-build/definitions/5.4.1
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.10
+++ b/share/php-build/definitions/5.4.10
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.10
+++ b/share/php-build/definitions/5.4.10
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.10.tar.bz2;h=4dbf54e08ee2fb77028aeefb5b03ee0713856a6c;hb=ee8236662d9af60e8f6c32212531bc16bb175266"

--- a/share/php-build/definitions/5.4.11
+++ b/share/php-build/definitions/5.4.11
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.11.tar.bz2;h=f1218b7345d8724b03061db374dccf8b3ff316e4;hb=e674fe7c2e0ba52772a723047a5b5ffc8db3bfb7"

--- a/share/php-build/definitions/5.4.11
+++ b/share/php-build/definitions/5.4.11
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.12
+++ b/share/php-build/definitions/5.4.12
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.12
+++ b/share/php-build/definitions/5.4.12
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.12.tar.bz2;h=36a855340fa72973a958d03827fa07a5b75cceed;hb=eb78a1bdd2dcdc1450420b592fb7c60a93bcb5b9"

--- a/share/php-build/definitions/5.4.13
+++ b/share/php-build/definitions/5.4.13
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.13
+++ b/share/php-build/definitions/5.4.13
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.13.tar.bz2;h=9fc012a888bc2cf7b5fb26e11eef4359c40b269f;hb=301a6d54e0efa1f0cf7b310b49ec03e17adca054"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.14
+++ b/share/php-build/definitions/5.4.14
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.14
+++ b/share/php-build/definitions/5.4.14
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.14.tar.bz2;h=0d950f179d586bb1d0e879e0d4aa3a5140e8d5f5;hb=3dd2f12609fc8a730d7cf341a932f6c7b241f03c"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.15
+++ b/share/php-build/definitions/5.4.15
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.15
+++ b/share/php-build/definitions/5.4.15
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.15.tar.bz2;h=a7ca6ec5c1792783158c2771f03f65c2c7312053;hb=34663c8d81e0619e23500c3d1a5c7f0d0a49905d"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.16
+++ b/share/php-build/definitions/5.4.16
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.16
+++ b/share/php-build/definitions/5.4.16
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.16.tar.bz2;h=855667f60cbb30f5d28ac6aed587c3da2f587f93;hb=b3d820892c8fe64be8026c239d625536a19f7372"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.17
+++ b/share/php-build/definitions/5.4.17
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.17
+++ b/share/php-build/definitions/5.4.17
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.17.tar.bz2;h=faa5b8ed7b6e154520fa09627c66b6404ca2f1be;hb=d052c0971b18b6d22b661a914a79be2da93327b5"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.18
+++ b/share/php-build/definitions/5.4.18
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.18.tar.bz2;h=17faefb906ae19191b6336135751331bee83098a;hb=512fc5d1b8622bdda0e41314b8e81d5133854caa"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.18
+++ b/share/php-build/definitions/5.4.18
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.19
+++ b/share/php-build/definitions/5.4.19
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.19
+++ b/share/php-build/definitions/5.4.19
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.19.tar.bz2;h=dc2babeb364e4767a1320546fced1386b867021d;hb=4c39e3c8edc074dc80077a00eab518be309a858d"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.2
+++ b/share/php-build/definitions/5.4.2
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.2
+++ b/share/php-build/definitions/5.4.2
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.20
+++ b/share/php-build/definitions/5.4.20
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.20.tar.bz2;h=df5951b5a74997cacae7bdc205cc7f9f69c9c7ce;hb=0d30c35745d0f3ad7a4bc26f84bbcc2d1782f678"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.20
+++ b/share/php-build/definitions/5.4.20
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.21
+++ b/share/php-build/definitions/5.4.21
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.21.tar.bz2;h=88f5bafb4f818ffbd9bba9d3cc835b391234ad51;hb=11e7eb77df43a899546be034a66c5679b2e0c939"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.21
+++ b/share/php-build/definitions/5.4.21
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.22
+++ b/share/php-build/definitions/5.4.22
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.22
+++ b/share/php-build/definitions/5.4.22
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.22.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.23
+++ b/share/php-build/definitions/5.4.23
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.23
+++ b/share/php-build/definitions/5.4.23
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.23.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.24
+++ b/share/php-build/definitions/5.4.24
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.24.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.24
+++ b/share/php-build/definitions/5.4.24
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.25
+++ b/share/php-build/definitions/5.4.25
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.25
+++ b/share/php-build/definitions/5.4.25
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.25.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.26
+++ b/share/php-build/definitions/5.4.26
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.26
+++ b/share/php-build/definitions/5.4.26
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.26.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.27
+++ b/share/php-build/definitions/5.4.27
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.27
+++ b/share/php-build/definitions/5.4.27
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.27.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.28
+++ b/share/php-build/definitions/5.4.28
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.28.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.28
+++ b/share/php-build/definitions/5.4.28
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.29
+++ b/share/php-build/definitions/5.4.29
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.29.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.29
+++ b/share/php-build/definitions/5.4.29
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.3
+++ b/share/php-build/definitions/5.4.3
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.3
+++ b/share/php-build/definitions/5.4.3
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.30
+++ b/share/php-build/definitions/5.4.30
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.30
+++ b/share/php-build/definitions/5.4.30
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.30.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.31
+++ b/share/php-build/definitions/5.4.31
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.31
+++ b/share/php-build/definitions/5.4.31
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.31.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.32
+++ b/share/php-build/definitions/5.4.32
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.32.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.32
+++ b/share/php-build/definitions/5.4.32
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.33
+++ b/share/php-build/definitions/5.4.33
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.33
+++ b/share/php-build/definitions/5.4.33
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.33.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.34
+++ b/share/php-build/definitions/5.4.34
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.34.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.34
+++ b/share/php-build/definitions/5.4.34
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.35
+++ b/share/php-build/definitions/5.4.35
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.35
+++ b/share/php-build/definitions/5.4.35
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.35.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.36
+++ b/share/php-build/definitions/5.4.36
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.36
+++ b/share/php-build/definitions/5.4.36
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.36.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.37
+++ b/share/php-build/definitions/5.4.37
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.37
+++ b/share/php-build/definitions/5.4.37
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.37.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.38
+++ b/share/php-build/definitions/5.4.38
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.38
+++ b/share/php-build/definitions/5.4.38
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.38.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.39
+++ b/share/php-build/definitions/5.4.39
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.39
+++ b/share/php-build/definitions/5.4.39
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.39.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.4
+++ b/share/php-build/definitions/5.4.4
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.4
+++ b/share/php-build/definitions/5.4.4
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.40
+++ b/share/php-build/definitions/5.4.40
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.40
+++ b/share/php-build/definitions/5.4.40
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.40.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.41
+++ b/share/php-build/definitions/5.4.41
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.41
+++ b/share/php-build/definitions/5.4.41
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.41.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.42
+++ b/share/php-build/definitions/5.4.42
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.42
+++ b/share/php-build/definitions/5.4.42
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.42.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.43
+++ b/share/php-build/definitions/5.4.43
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.43
+++ b/share/php-build/definitions/5.4.43
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.43.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.44
+++ b/share/php-build/definitions/5.4.44
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.44
+++ b/share/php-build/definitions/5.4.44
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.44.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.45
+++ b/share/php-build/definitions/5.4.45
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.45
+++ b/share/php-build/definitions/5.4.45
@@ -8,5 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.4.45.tar.bz2"
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.4.5
+++ b/share/php-build/definitions/5.4.5
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.5
+++ b/share/php-build/definitions/5.4.5
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.6
+++ b/share/php-build/definitions/5.4.6
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.6
+++ b/share/php-build/definitions/5.4.6
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.6-libxml2-2.9.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 

--- a/share/php-build/definitions/5.4.7
+++ b/share/php-build/definitions/5.4.7
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.7
+++ b/share/php-build/definitions/5.4.7
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.7.tar.bz2;h=718133ae425fa4236c6c17536959c07f18a1ee45;hb=5dde46e9635c40cb0515118a2e46ee015b14984e"

--- a/share/php-build/definitions/5.4.8
+++ b/share/php-build/definitions/5.4.8
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.8
+++ b/share/php-build/definitions/5.4.8
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.8.tar.bz2;h=336267f83d03428851e58477bccf1478211dcbe1;hb=64f1ac741d14dc9a1dbfbe9416619537a7cd2fba"

--- a/share/php-build/definitions/5.4.9
+++ b/share/php-build/definitions/5.4.9
@@ -1,4 +1,5 @@
 autoconf_version 2.64
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.9
+++ b/share/php-build/definitions/5.4.9
@@ -8,6 +8,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
 patch_file "php-5.4.12-support-c++11.patch"
 
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.4.9.tar.bz2;h=452c44736d8391f5e1c89fab62ad47d553f40f4d;hb=685e095dd2b8443b8031a8d5628eabc556a89e1d"

--- a/share/php-build/definitions/5.4snapshot
+++ b/share/php-build/definitions/5.4snapshot
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4snapshot
+++ b/share/php-build/definitions/5.4snapshot
@@ -7,5 +7,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.4-curl-config.patch"
+
 install_package_from_github PHP-5.4
 install_xdebug "2.4.1"

--- a/share/php-build/definitions/5.5.0
+++ b/share/php-build/definitions/5.5.0
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.0
+++ b/share/php-build/definitions/5.5.0
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.0.tar.bz2;h=a9d7b5dbc92f9ff99fcaf911047d8c7d465160cf;hb=01253f21cc75bf10e8698d0be9a904ee4f020a99"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.1
+++ b/share/php-build/definitions/5.5.1
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.1.tar.bz2;h=7bf5067be413ff11127904468a7c308152916a80;hb=703b7b0367bb661e9d5ce2ec6f1e9f57f3418b84"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.1
+++ b/share/php-build/definitions/5.5.1
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.10
+++ b/share/php-build/definitions/5.5.10
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.10
+++ b/share/php-build/definitions/5.5.10
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.10.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.11
+++ b/share/php-build/definitions/5.5.11
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.11
+++ b/share/php-build/definitions/5.5.11
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.11.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.12
+++ b/share/php-build/definitions/5.5.12
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.12
+++ b/share/php-build/definitions/5.5.12
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.12.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.13
+++ b/share/php-build/definitions/5.5.13
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.13.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.13
+++ b/share/php-build/definitions/5.5.13
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.14
+++ b/share/php-build/definitions/5.5.14
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.14.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.14
+++ b/share/php-build/definitions/5.5.14
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.15
+++ b/share/php-build/definitions/5.5.15
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.15
+++ b/share/php-build/definitions/5.5.15
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.15.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.16
+++ b/share/php-build/definitions/5.5.16
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.16
+++ b/share/php-build/definitions/5.5.16
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.16.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.17
+++ b/share/php-build/definitions/5.5.17
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.17
+++ b/share/php-build/definitions/5.5.17
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.17.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.18
+++ b/share/php-build/definitions/5.5.18
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.18
+++ b/share/php-build/definitions/5.5.18
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.18.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.19
+++ b/share/php-build/definitions/5.5.19
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.19
+++ b/share/php-build/definitions/5.5.19
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.19.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.2
+++ b/share/php-build/definitions/5.5.2
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.2
+++ b/share/php-build/definitions/5.5.2
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.2.tar.bz2;h=ef23e90fcdc65ec8bfe2c3100780ceaf62951dde;hb=cb66297df342fd7e2e11d4c952d0793e971a3886"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.20
+++ b/share/php-build/definitions/5.5.20
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.20
+++ b/share/php-build/definitions/5.5.20
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.20.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.21
+++ b/share/php-build/definitions/5.5.21
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.21.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.21
+++ b/share/php-build/definitions/5.5.21
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.22
+++ b/share/php-build/definitions/5.5.22
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.22
+++ b/share/php-build/definitions/5.5.22
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.22.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.23
+++ b/share/php-build/definitions/5.5.23
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.23
+++ b/share/php-build/definitions/5.5.23
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.23.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.24
+++ b/share/php-build/definitions/5.5.24
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.24.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.24
+++ b/share/php-build/definitions/5.5.24
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.25
+++ b/share/php-build/definitions/5.5.25
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.25
+++ b/share/php-build/definitions/5.5.25
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.25.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.26
+++ b/share/php-build/definitions/5.5.26
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.26
+++ b/share/php-build/definitions/5.5.26
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.26.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.27
+++ b/share/php-build/definitions/5.5.27
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.27
+++ b/share/php-build/definitions/5.5.27
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.27.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.28
+++ b/share/php-build/definitions/5.5.28
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.28.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.28
+++ b/share/php-build/definitions/5.5.28
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.29
+++ b/share/php-build/definitions/5.5.29
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.29
+++ b/share/php-build/definitions/5.5.29
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.29.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.3
+++ b/share/php-build/definitions/5.5.3
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.3
+++ b/share/php-build/definitions/5.5.3
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.3.tar.bz2;h=2f8f088ff89cb77873798a58027dcf68271f4cda;hb=4c39e3c8edc074dc80077a00eab518be309a858d"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.30
+++ b/share/php-build/definitions/5.5.30
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.30
+++ b/share/php-build/definitions/5.5.30
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.30.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.31
+++ b/share/php-build/definitions/5.5.31
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.31
+++ b/share/php-build/definitions/5.5.31
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.31.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.32
+++ b/share/php-build/definitions/5.5.32
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.32
+++ b/share/php-build/definitions/5.5.32
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.32.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.33
+++ b/share/php-build/definitions/5.5.33
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.33
+++ b/share/php-build/definitions/5.5.33
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.33.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.34
+++ b/share/php-build/definitions/5.5.34
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.34.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.34
+++ b/share/php-build/definitions/5.5.34
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.35
+++ b/share/php-build/definitions/5.5.35
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.35
+++ b/share/php-build/definitions/5.5.35
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.35.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.36
+++ b/share/php-build/definitions/5.5.36
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.36
+++ b/share/php-build/definitions/5.5.36
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.36.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.37
+++ b/share/php-build/definitions/5.5.37
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.37.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.37
+++ b/share/php-build/definitions/5.5.37
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.38
+++ b/share/php-build/definitions/5.5.38
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.38
+++ b/share/php-build/definitions/5.5.38
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.38.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.4
+++ b/share/php-build/definitions/5.5.4
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.4
+++ b/share/php-build/definitions/5.5.4
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://git.php.net/?p=web/php-distributions.git;a=blob;f=php-5.5.4.tar.bz2;h=6f258d1d91f812f7d7d717dba75e086b796381fd;hb=d57019e4b0bfcaa4d37288c7c7e346ed50ae04a1"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.5
+++ b/share/php-build/definitions/5.5.5
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.5
+++ b/share/php-build/definitions/5.5.5
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.5.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.6
+++ b/share/php-build/definitions/5.5.6
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.6
+++ b/share/php-build/definitions/5.5.6
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.6.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.7
+++ b/share/php-build/definitions/5.5.7
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.7.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.7
+++ b/share/php-build/definitions/5.5.7
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.8
+++ b/share/php-build/definitions/5.5.8
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5.8
+++ b/share/php-build/definitions/5.5.8
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.8.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.9
+++ b/share/php-build/definitions/5.5.9
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.5.9.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.5.9
+++ b/share/php-build/definitions/5.5.9
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5snapshot
+++ b/share/php-build/definitions/5.5snapshot
@@ -1,3 +1,4 @@
+configure_option -D "--enable-phpdbg"
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.5snapshot
+++ b/share/php-build/definitions/5.5snapshot
@@ -7,6 +7,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package_from_github PHP-5.5
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.0
+++ b/share/php-build/definitions/5.6.0
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.0.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.1
+++ b/share/php-build/definitions/5.6.1
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.1.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.10
+++ b/share/php-build/definitions/5.6.10
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.10.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.11
+++ b/share/php-build/definitions/5.6.11
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.11.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.12
+++ b/share/php-build/definitions/5.6.12
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.12.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.13
+++ b/share/php-build/definitions/5.6.13
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.13.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.14
+++ b/share/php-build/definitions/5.6.14
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.14.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.15
+++ b/share/php-build/definitions/5.6.15
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.15.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.16
+++ b/share/php-build/definitions/5.6.16
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.16.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.17
+++ b/share/php-build/definitions/5.6.17
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.17.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.18
+++ b/share/php-build/definitions/5.6.18
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.18.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.19
+++ b/share/php-build/definitions/5.6.19
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.19.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.2
+++ b/share/php-build/definitions/5.6.2
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.2.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.20
+++ b/share/php-build/definitions/5.6.20
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.20.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.21
+++ b/share/php-build/definitions/5.6.21
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.21.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.22
+++ b/share/php-build/definitions/5.6.22
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.22.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.23
+++ b/share/php-build/definitions/5.6.23
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.23.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.24
+++ b/share/php-build/definitions/5.6.24
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.24.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.25
+++ b/share/php-build/definitions/5.6.25
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.25.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.26
+++ b/share/php-build/definitions/5.6.26
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.26.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.27
+++ b/share/php-build/definitions/5.6.27
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.27.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.28
+++ b/share/php-build/definitions/5.6.28
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.28.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.29
+++ b/share/php-build/definitions/5.6.29
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.29.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.3
+++ b/share/php-build/definitions/5.6.3
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.3.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.30
+++ b/share/php-build/definitions/5.6.30
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.30.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.31
+++ b/share/php-build/definitions/5.6.31
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.31.tar.bz2"

--- a/share/php-build/definitions/5.6.32
+++ b/share/php-build/definitions/5.6.32
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.32.tar.bz2"

--- a/share/php-build/definitions/5.6.33
+++ b/share/php-build/definitions/5.6.33
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.33.tar.bz2"

--- a/share/php-build/definitions/5.6.34
+++ b/share/php-build/definitions/5.6.34
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.34.tar.bz2"

--- a/share/php-build/definitions/5.6.35
+++ b/share/php-build/definitions/5.6.35
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.35.tar.bz2"

--- a/share/php-build/definitions/5.6.36
+++ b/share/php-build/definitions/5.6.36
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.36.tar.bz2"

--- a/share/php-build/definitions/5.6.37
+++ b/share/php-build/definitions/5.6.37
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.37.tar.bz2"

--- a/share/php-build/definitions/5.6.38
+++ b/share/php-build/definitions/5.6.38
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.38.tar.bz2"

--- a/share/php-build/definitions/5.6.39
+++ b/share/php-build/definitions/5.6.39
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.39.tar.bz2"

--- a/share/php-build/definitions/5.6.4
+++ b/share/php-build/definitions/5.6.4
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.4.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.40
+++ b/share/php-build/definitions/5.6.40
@@ -6,6 +6,7 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
 patch_file "php-5.6-support-openssl-1.1.0.patch"
 
 install_package "https://secure.php.net/distributions/php-5.6.40.tar.bz2"

--- a/share/php-build/definitions/5.6.5
+++ b/share/php-build/definitions/5.6.5
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.5.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.6
+++ b/share/php-build/definitions/5.6.6
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.6.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.7
+++ b/share/php-build/definitions/5.6.7
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.7.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.8
+++ b/share/php-build/definitions/5.6.8
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.8.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6.9
+++ b/share/php-build/definitions/5.6.9
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package "https://secure.php.net/distributions/php-5.6.9.tar.bz2"
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/definitions/5.6snapshot
+++ b/share/php-build/definitions/5.6snapshot
@@ -6,6 +6,8 @@ configure_option "--with-png-dir" "/usr"
 configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
+patch_file "php-5.6-curl-config.patch"
+
 install_package_from_github PHP-5.6
 install_xdebug "2.5.5"
 enable_builtin_opcache

--- a/share/php-build/patches/php-5.4-curl-config.patch
+++ b/share/php-build/patches/php-5.4-curl-config.patch
@@ -1,0 +1,131 @@
+From f8155e1d546f046365a168bf6a8fba50ea5cfe79 Mon Sep 17 00:00:00 2001
+From: Remi Collet <remi@remirepo.net>
+Date: Fri, 18 Aug 2017 15:01:16 +0200
+Subject: [PATCH] Switch from curl-config to pkg-config for curl extension
+
+First attemp to fix multiarch support (#74125) for curl
+introduce some debian specificity (dpkg command)
+so is not suitable for other environmant.
+
+This is mostly related to a broken "curl-config" config on debian
+which doesn't provide the correct build options, while pkg-config
+works as expected.
+
+This new attemp rely on pkg-config output instead.
+
+Notice: this make pkg-config a hard dependency.
+Is there system without pkg-config ?
+
+(cherry picked from commit b8c6ce91b24d314fe9f9996a17942b63ecec249b)
+---
+ ext/curl/config.m4 | 56 +++++++++++++++++++++++++++++++++++++++-------
+ 1 file changed, 48 insertions(+), 8 deletions(-)
+
+diff --git a/ext/curl/config.m4 b/ext/curl/config.m4
+index fbb4f5b4e5..8fc332be41 100644
+--- a/ext/curl/config.m4
++++ b/ext/curl/config.m4
+@@ -10,6 +10,41 @@ PHP_ARG_WITH(curlwrappers, if we should use cURL for url streams,
+ [  --with-curlwrappers     EXPERIMENTAL: Use cURL for url streams], no, no)
+ 
+ if test "$PHP_CURL" != "no"; then
++  if test -z "$PKG_CONFIG"; then
++    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
++  fi
++
++  if test -x "$PKG_CONFIG"; then
++    dnl using pkg-config output
++
++    AC_MSG_CHECKING(for libcurl.pc)
++    if test "$PHP_CURL" = "yes"; then
++      PKNAME=libcurl
++      AC_MSG_RESULT(using default path)
++    elif test -r $PHP_CURL/$PHP_LIBDIR/pkgconfig/libcurl.pc; then
++      PKNAME=$PHP_CURL/$PHP_LIBDIR/pkgconfig/libcurl.pc
++      AC_MSG_RESULT(using $PKNAME)
++    elif test -r $PHP_CURL/lib/pkgconfig/libcurl.pc; then
++      PKNAME=$PHP_CURL/lib/pkgconfig/libcurl.pc
++      AC_MSG_RESULT(using $PKNAME)
++    else
++      AC_MSG_ERROR(Could not find libcurl.pc)
++    fi
++
++    AC_MSG_CHECKING(for cURL 7.10.5 or greater)
++    if $PKG_CONFIG --atleast-version 7.10.5 $PKNAME; then
++      curl_version_full=`$PKG_CONFIG --modversion $PKNAME`
++      AC_MSG_RESULT($curl_version_full)
++    else
++      AC_MSG_ERROR(cURL version 7.10.5 or later is required to compile php with cURL support)
++    fi
++
++    CURL_LIBS=`$PKG_CONFIG --libs   $PKNAME`
++    CURL_INCL=`$PKG_CONFIG --cflags $PKNAME`
++    CURL_SSL=`$PKG_CONFIG --variable=supported_features $PKNAME| $EGREP SSL`
++  else
++    dnl fallback to old way, using curl-config
++
+   if test -r $PHP_CURL/include/curl/easy.h; then
+     CURL_DIR=$PHP_CURL
+   else
+@@ -45,22 +80,27 @@ if test "$PHP_CURL" != "no"; then
+   if test "$curl_version" -ge 7010005; then
+     AC_MSG_RESULT($curl_version_full)
+     CURL_LIBS=`$CURL_CONFIG --libs`
++      CURL_INCL=`$CURL_CONFIG --cflags`
++      CURL_SSL=`$CURL_CONFIG --feature | $EGREP SSL`
+   else
+     AC_MSG_ERROR(cURL version 7.10.5 or later is required to compile php with cURL support)
+   fi
++  fi
++
++  dnl common stuff (pkg-config / curl-config)
+ 
+-  PHP_ADD_INCLUDE($CURL_DIR/include)
+   PHP_EVAL_LIBLINE($CURL_LIBS, CURL_SHARED_LIBADD)
+-  PHP_ADD_LIBRARY_WITH_PATH(curl, $CURL_DIR/$PHP_LIBDIR, CURL_SHARED_LIBADD)
++  PHP_EVAL_INCLINE($CURL_INCL, CURL_SHARED_LIBADD)
+   
+   AC_MSG_CHECKING([for SSL support in libcurl])
+-  CURL_SSL=`$CURL_CONFIG --feature | $EGREP SSL`
+-  if test "$CURL_SSL" = "SSL"; then
++  if test -n "$CURL_SSL"; then
+     AC_MSG_RESULT([yes])
+     AC_DEFINE([HAVE_CURL_SSL], [1], [Have cURL with  SSL support])
+    
+     save_CFLAGS="$CFLAGS"
+-    CFLAGS="`$CURL_CONFIG --cflags`"
++    CFLAGS=$CURL_INCL
++    save_LDFLAGS="$CFLAGS"
++    LDFLAGS=$CURL_LIBS
+    
+     AC_PROG_CPP
+     AC_MSG_CHECKING([for openssl support in libcurl])
+@@ -128,7 +168,7 @@ int main(int argc, char *argv[])
+   ],[
+     AC_MSG_ERROR(There is something wrong. Please check config.log for more information.)
+   ],[
+-    $CURL_LIBS -L$CURL_DIR/$PHP_LIBDIR
++    $CURL_LIBS
+   ])
+ 
+   PHP_CHECK_LIBRARY(curl,curl_version_info,
+@@ -142,14 +182,14 @@ int main(int argc, char *argv[])
+   [
+     AC_DEFINE(HAVE_CURL_EASY_STRERROR,1,[ ])
+   ],[],[
+-    $CURL_LIBS -L$CURL_DIR/$PHP_LIBDIR
++    $CURL_LIBS
+   ])
+ 
+   PHP_CHECK_LIBRARY(curl,curl_multi_strerror,
+   [
+     AC_DEFINE(HAVE_CURL_MULTI_STRERROR,1,[ ])
+   ],[],[
+-    $CURL_LIBS -L$CURL_DIR/$PHP_LIBDIR
++    $CURL_LIBS
+   ])
+ 
+   if test "$PHP_CURLWRAPPERS" != "no" ; then
+-- 
+2.28.0
+

--- a/share/php-build/patches/php-5.6-curl-config.patch
+++ b/share/php-build/patches/php-5.6-curl-config.patch
@@ -1,0 +1,130 @@
+From f404e2f4d7cb79375004cd8d784d2c6614d00500 Mon Sep 17 00:00:00 2001
+From: Remi Collet <remi@remirepo.net>
+Date: Fri, 18 Aug 2017 15:01:16 +0200
+Subject: [PATCH] Switch from curl-config to pkg-config for curl extension
+
+First attemp to fix multiarch support (#74125) for curl
+introduce some debian specificity (dpkg command)
+so is not suitable for other environmant.
+
+This is mostly related to a broken "curl-config" config on debian
+which doesn't provide the correct build options, while pkg-config
+works as expected.
+
+This new attemp rely on pkg-config output instead.
+
+Notice: this make pkg-config a hard dependency.
+Is there system without pkg-config ?
+
+(cherry picked from commit b8c6ce91b24d314fe9f9996a17942b63ecec249b)
+---
+ ext/curl/config.m4 | 56 +++++++++++++++++++++++++++++++++++++++-------
+ 1 file changed, 48 insertions(+), 8 deletions(-)
+
+diff --git a/ext/curl/config.m4 b/ext/curl/config.m4
+index 2f82c3485d..c40f2db6f0 100644
+--- a/ext/curl/config.m4
++++ b/ext/curl/config.m4
+@@ -6,6 +6,41 @@ PHP_ARG_WITH(curl, for cURL support,
+ [  --with-curl[=DIR]         Include cURL support])
+ 
+ if test "$PHP_CURL" != "no"; then
++  if test -z "$PKG_CONFIG"; then
++    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
++  fi
++
++  if test -x "$PKG_CONFIG"; then
++    dnl using pkg-config output
++
++    AC_MSG_CHECKING(for libcurl.pc)
++    if test "$PHP_CURL" == "yes"; then
++      PKNAME=libcurl
++      AC_MSG_RESULT(using default path)
++    elif test -r $PHP_CURL/$PHP_LIBDIR/pkgconfig/libcurl.pc; then
++      PKNAME=$PHP_CURL/$PHP_LIBDIR/pkgconfig/libcurl.pc
++      AC_MSG_RESULT(using $PKNAME)
++    elif test -r $PHP_CURL/lib/pkgconfig/libcurl.pc; then
++      PKNAME=$PHP_CURL/lib/pkgconfig/libcurl.pc
++      AC_MSG_RESULT(using $PKNAME)
++    else
++      AC_MSG_ERROR(Could not find libcurl.pc)
++    fi
++
++    AC_MSG_CHECKING(for cURL 7.10.5 or greater)
++    if $PKG_CONFIG --atleast-version 7.10.5 $PKNAME; then
++      curl_version_full=`$PKG_CONFIG --modversion $PKNAME`
++      AC_MSG_RESULT($curl_version_full)
++    else
++      AC_MSG_ERROR(cURL version 7.10.5 or later is required to compile php with cURL support)
++    fi
++
++    CURL_LIBS=`$PKG_CONFIG --libs   $PKNAME`
++    CURL_INCL=`$PKG_CONFIG --cflags $PKNAME`
++    CURL_SSL=`$PKG_CONFIG --variable=supported_features $PKNAME| $EGREP SSL`
++  else
++    dnl fallback to old way, using curl-config
++
+   if test -r $PHP_CURL/include/curl/easy.h; then
+     CURL_DIR=$PHP_CURL
+   else
+@@ -41,22 +76,27 @@ if test "$PHP_CURL" != "no"; then
+   if test "$curl_version" -ge 7010005; then
+     AC_MSG_RESULT($curl_version_full)
+     CURL_LIBS=`$CURL_CONFIG --libs`
++      CURL_INCL=`$CURL_CONFIG --cflags`
++      CURL_SSL=`$CURL_CONFIG --feature | $EGREP SSL`
+   else
+     AC_MSG_ERROR(cURL version 7.10.5 or later is required to compile php with cURL support)
+   fi
++  fi
++
++  dnl common stuff (pkg-config / curl-config)
+ 
+-  PHP_ADD_INCLUDE($CURL_DIR/include)
+   PHP_EVAL_LIBLINE($CURL_LIBS, CURL_SHARED_LIBADD)
+-  PHP_ADD_LIBRARY_WITH_PATH(curl, $CURL_DIR/$PHP_LIBDIR, CURL_SHARED_LIBADD)
++  PHP_EVAL_INCLINE($CURL_INCL, CURL_SHARED_LIBADD)
+   
+   AC_MSG_CHECKING([for SSL support in libcurl])
+-  CURL_SSL=`$CURL_CONFIG --feature | $EGREP SSL`
+-  if test "$CURL_SSL" = "SSL"; then
++  if test -n "$CURL_SSL"; then
+     AC_MSG_RESULT([yes])
+     AC_DEFINE([HAVE_CURL_SSL], [1], [Have cURL with  SSL support])
+    
+     save_CFLAGS="$CFLAGS"
+-    CFLAGS="`$CURL_CONFIG --cflags`"
++    CFLAGS=$CURL_INCL
++    save_LDFLAGS="$CFLAGS"
++    LDFLAGS=$CURL_LIBS
+    
+     AC_PROG_CPP
+     AC_MSG_CHECKING([for openssl support in libcurl])
+@@ -124,21 +164,21 @@ int main(int argc, char *argv[])
+   ],[
+     AC_MSG_ERROR(There is something wrong. Please check config.log for more information.)
+   ],[
+-    $CURL_LIBS -L$CURL_DIR/$PHP_LIBDIR
++    $CURL_LIBS
+   ])
+ 
+   PHP_CHECK_LIBRARY(curl,curl_easy_strerror,
+   [
+     AC_DEFINE(HAVE_CURL_EASY_STRERROR,1,[ ])
+   ],[],[
+-    $CURL_LIBS -L$CURL_DIR/$PHP_LIBDIR
++    $CURL_LIBS
+   ])
+ 
+   PHP_CHECK_LIBRARY(curl,curl_multi_strerror,
+   [
+     AC_DEFINE(HAVE_CURL_MULTI_STRERROR,1,[ ])
+   ],[],[
+-    $CURL_LIBS -L$CURL_DIR/$PHP_LIBDIR
++    $CURL_LIBS
+   ])
+ 
+   PHP_NEW_EXTENSION(curl, interface.c multi.c share.c curl_file.c, $ext_shared)
+-- 
+2.27.0
+


### PR DESCRIPTION
Old PHP releases fail to detect curl in distros with multiarch paths
(e.g. Ubuntu 20.04). This had an initial fix in PHP 7 that was
Debian-specific and then a distro-agnostic fix in PHP 7.2.

The original patches in php-src:

- https://github.com/php/php-src/commit/3fd7d819b8ea164bdf255cddcd0a1b1d156f4a3b
- https://github.com/php/php-src/commit/b8c6ce91b24d314fe9f9996a17942b63ecec249b

This commit adds a backport of the later to PHP 5.6, and it should apply
cleanly to all versions back to 5.4.

This also requires changing the default config flag --with-curl=/url to
just --with-curl to let auto-detection run.