### PR TITLE
Replace which with command -v

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -651,12 +651,12 @@ function configure_package() {
 
     # Override `--with-openssl` and `--with-libxml-dir`
     # if Homebrew's openssl and libxml2 exist on Mac OS X 10.11+.
-    if is_osx && [ "$(osx_major)" -eq 10 ] && [ "$(osx_minor)" -ge 11 ] && [ -n "$(which brew)" ] && [ -e "$(brew --prefix openssl)" ] && [ -e "$(brew --prefix libxml2)" ]; then
+    if is_osx && [ "$(osx_major)" -eq 10 ] && [ "$(osx_minor)" -ge 11 ] && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix openssl)" ] && [ -e "$(brew --prefix libxml2)" ]; then
         configure_option -R "--with-openssl" "$(brew --prefix openssl)"
         configure_option -R "--with-libxml-dir" "$(brew --prefix libxml2)"
     fi
 
-    if is_osx && [ -n "$(which brew)" ] && [ -e "$(brew --prefix icu4c)" ]; then
+    if is_osx && [ -n "$(command -v brew)" ] && [ -e "$(brew --prefix icu4c)" ]; then
         configure_option "--with-icu-dir" "$(brew --prefix icu4c)"
         # icu4c 59+ requires C++11
         if [[ -z "$CXXFLAGS" && $($(brew --prefix icu4c)/bin/icu-config --version) > "61" ]]; then

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -28,7 +28,7 @@ update_gh_pages() {
 VERSION="$1"
 
 if [ -z "$RONN_PATH" ]; then
-    ronn=$(which ronn)
+    ronn="$(command -v ronn)"
 else
     ronn="$RONN_PATH"
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -15,7 +15,7 @@ usage() {
     echo "Usage: ./run-tests.sh all|stable|<definition>,..."
 }
 
-if ! which "bats" > /dev/null; then
+if ! command -v bats > /dev/null; then
     echo "You need http://github.com/sstephenson/bats installed." >&2
     exit 1
 fi


### PR DESCRIPTION
`which` is less available than the POSIX standard `command -v`. For example, `which`
is not available in centos:8 docker images.

More info:
https://github.com/koalaman/shellcheck/wiki/SC2230