### PR TITLE
set libdir to lib64 only if it exists

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -689,15 +689,17 @@ $CONFIGURE_OPTIONS"
         mkdir -p "$PREFIX/libexec"
     fi
 
-    # Set the lib dir to `lib64` on **x86_64**
-    # systems.
+    # x86_64 multiarch systems may have lib, lib32 and lib64.
+    # In older distros, lib64 is the default directory for x86_64 libraries
+    # while on modern distros it's just lib. If no --with-libdir is provided
+    # and /usr/lib64 exists, then we set --with-libdir=lib64.
     local append_default_libdir='yes'
     for option in $CONFIGURE_OPTIONS; do
       case "$option" in
         "--with-libdir"*) append_default_libdir='no' ;;
       esac
     done
-    if [ "$(uname -p)" = "x86_64" ] && [ "${append_default_libdir}" = 'yes' ]; then
+    if [ "$(uname -p)" = "x86_64" ] && [ "${append_default_libdir}" = 'yes' ] && [ -d /usr/lib64 ]; then
         argv="$argv --with-libdir=lib64"
     fi
 


### PR DESCRIPTION
Modern Linux distros use lib for x86_64 libraries (not lib64). Set
--with-libdir=lib64 only if /usr/lib64 exists. This fixes builds with
--with-openssl=[custom dir] on recent Ubuntu versions.