### PR TITLE
set PHP_AUTOCONF automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,6 @@ before_install:
         fi
         if [[ "$DEFINITION" =~ ^("5.2.".*|"5.3.".*)$ ]]; then
             sudo apt-get install -y autoconf2.13
-            export PHP_AUTOCONF=/usr/bin/autoconf2.13
         fi
         if [[ "$DEFINITION" =~ ^("7.3.".*)$ ]]; then
             export PHP_BUILD_CONFIGURE_OPTS="--without-libzip"
@@ -132,7 +131,6 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         if [[ "$DEFINITION" =~ ^("5.3.".*)$ ]]; then
             brew install autoconf@2.13
-            export PHP_AUTOCONF=$(brew --prefix autoconf@2.13)/bin/autoconf213
             export LIBS="-lssl -lcrypto"
         fi
         if [[ "$DEFINITION" =~ ^("5.".*)$ ]]; then

--- a/bin/php-build
+++ b/bin/php-build
@@ -512,6 +512,35 @@ function definition_package_name() {
     echo "php-$DEFINITION"
 }
 
+# ### autoconf_version
+#
+# Requires an old autoconf version. Valid values are 2.13 and 2.64, which are
+# commonly shipped with most Linux distros.
+function autoconf_version() {
+    local ver="$1"
+    # if the user has set PHP_AUTOCONF, honor it and ignore this command.
+    if [[ -n "${PHP_AUTOCONF}" ]]; then
+        return
+    fi
+    # Debian-like pattern
+    if command -v "autoconf$ver" &> /dev/null; then
+        export PHP_AUTOCONF="autoconf$ver"
+        return
+    fi
+    # RHEL-like pattern
+    if command -v "autoconf-$ver" &> /dev/null; then
+        export PHP_AUTOCONF="autoconf-$ver"
+        return
+    fi
+    # macOS+Homebrew
+    if is_osx && brew --prefix "autoconf@$ver" &> /dev/null; then
+        PHP_AUTOCONF="$(brew --prefix "autoconf@$ver")/bin/autoconf${ver//./}"
+        export PHP_AUTOCONF
+        return
+    fi
+    # no luck, let's hope that system's autoconf is compatible
+}
+
 # ### configure_option
 #
 # This function sets and unsets arguments for `configure`. Pass it

--- a/share/php-build/definitions/5.2.17
+++ b/share/php-build/definitions/5.2.17
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--enable-fastcgi"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.10
+++ b/share/php-build/definitions/5.3.10
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.11
+++ b/share/php-build/definitions/5.3.11
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.12
+++ b/share/php-build/definitions/5.3.12
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.13
+++ b/share/php-build/definitions/5.3.13
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.14
+++ b/share/php-build/definitions/5.3.14
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.15
+++ b/share/php-build/definitions/5.3.15
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.16
+++ b/share/php-build/definitions/5.3.16
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.17
+++ b/share/php-build/definitions/5.3.17
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.18
+++ b/share/php-build/definitions/5.3.18
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.19
+++ b/share/php-build/definitions/5.3.19
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.2
+++ b/share/php-build/definitions/5.3.2
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.20
+++ b/share/php-build/definitions/5.3.20
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.21
+++ b/share/php-build/definitions/5.3.21
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.22
+++ b/share/php-build/definitions/5.3.22
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.23
+++ b/share/php-build/definitions/5.3.23
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.24
+++ b/share/php-build/definitions/5.3.24
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.25
+++ b/share/php-build/definitions/5.3.25
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.26
+++ b/share/php-build/definitions/5.3.26
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.27
+++ b/share/php-build/definitions/5.3.27
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.28
+++ b/share/php-build/definitions/5.3.28
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.29
+++ b/share/php-build/definitions/5.3.29
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.3
+++ b/share/php-build/definitions/5.3.3
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.6
+++ b/share/php-build/definitions/5.3.6
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.8
+++ b/share/php-build/definitions/5.3.8
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.3.9
+++ b/share/php-build/definitions/5.3.9
@@ -1,3 +1,4 @@
+autoconf_version 2.13
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.0
+++ b/share/php-build/definitions/5.4.0
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.1
+++ b/share/php-build/definitions/5.4.1
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.10
+++ b/share/php-build/definitions/5.4.10
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.11
+++ b/share/php-build/definitions/5.4.11
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.12
+++ b/share/php-build/definitions/5.4.12
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.13
+++ b/share/php-build/definitions/5.4.13
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.14
+++ b/share/php-build/definitions/5.4.14
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.15
+++ b/share/php-build/definitions/5.4.15
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.16
+++ b/share/php-build/definitions/5.4.16
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.17
+++ b/share/php-build/definitions/5.4.17
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.18
+++ b/share/php-build/definitions/5.4.18
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.19
+++ b/share/php-build/definitions/5.4.19
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.2
+++ b/share/php-build/definitions/5.4.2
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.20
+++ b/share/php-build/definitions/5.4.20
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.21
+++ b/share/php-build/definitions/5.4.21
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.22
+++ b/share/php-build/definitions/5.4.22
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.23
+++ b/share/php-build/definitions/5.4.23
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.24
+++ b/share/php-build/definitions/5.4.24
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.25
+++ b/share/php-build/definitions/5.4.25
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.26
+++ b/share/php-build/definitions/5.4.26
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.27
+++ b/share/php-build/definitions/5.4.27
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.28
+++ b/share/php-build/definitions/5.4.28
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.29
+++ b/share/php-build/definitions/5.4.29
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.3
+++ b/share/php-build/definitions/5.4.3
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.30
+++ b/share/php-build/definitions/5.4.30
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.31
+++ b/share/php-build/definitions/5.4.31
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.32
+++ b/share/php-build/definitions/5.4.32
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.33
+++ b/share/php-build/definitions/5.4.33
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.34
+++ b/share/php-build/definitions/5.4.34
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.35
+++ b/share/php-build/definitions/5.4.35
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.36
+++ b/share/php-build/definitions/5.4.36
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.37
+++ b/share/php-build/definitions/5.4.37
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.38
+++ b/share/php-build/definitions/5.4.38
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.39
+++ b/share/php-build/definitions/5.4.39
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.4
+++ b/share/php-build/definitions/5.4.4
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.40
+++ b/share/php-build/definitions/5.4.40
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.41
+++ b/share/php-build/definitions/5.4.41
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.42
+++ b/share/php-build/definitions/5.4.42
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.43
+++ b/share/php-build/definitions/5.4.43
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.44
+++ b/share/php-build/definitions/5.4.44
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.45
+++ b/share/php-build/definitions/5.4.45
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.5
+++ b/share/php-build/definitions/5.4.5
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.6
+++ b/share/php-build/definitions/5.4.6
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.7
+++ b/share/php-build/definitions/5.4.7
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.8
+++ b/share/php-build/definitions/5.4.8
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"

--- a/share/php-build/definitions/5.4.9
+++ b/share/php-build/definitions/5.4.9
@@ -1,3 +1,4 @@
+autoconf_version 2.64
 configure_option "--with-mysql" "mysqlnd"
 configure_option "--with-mcrypt" "/usr"
 configure_option "--without-pear"


### PR DESCRIPTION
Old PHP versions require older autoconf. Linux distros as well as
Homebrew on macOS include multiple autoconf versions and they can be
used with PHP with the PHP_AUTOCONF environment variable.

This change tries to set PHP_AUTOCONF automatically. If the user already
set PHP_AUTOCONF, then no detection is attempted.