### PR TITLE
Add dependency installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,33 +2,8 @@ language: c
 
 addons:
   apt:
-    sources:
-      - sourceline: 'ppa:ondrej/php'
-    packages:
-      - libicu-dev
-      - libmcrypt-dev
-      - libonig-dev
-      - libtidy-dev
-      - libzip-dev
-      - libjpeg-dev
-      - libxml2-dev
-      - libsqlite3-dev
-      - re2c
-      - bison
     update: true
   homebrew:
-    packages:
-      - icu4c
-      - krb5
-      - libedit
-      - libmcrypt
-      - libxml2
-      - libzip
-      - libjpeg
-      - oniguruma
-      - openssl
-      - python
-      - re2c
     update: true
 
 matrix:
@@ -36,38 +11,18 @@ matrix:
     - os: linux
       dist: trusty
       env: DEFINITION=5.2.17
-      addons:
-        apt:
-          packges:
-            - php5-cli
     - os: linux
       dist: trusty
       env: DEFINITION=5.3.29
-      addons:
-        apt:
-          packges:
-            - php5-cli
     - os: linux
       dist: trusty
       env: DEFINITION=5.4.45
-      addons:
-        apt:
-          packges:
-            - php5-cli
     - os: linux
       dist: trusty
       env: DEFINITION=5.5.38
-      addons:
-        apt:
-          packges:
-            - php5-cli
     - os: linux
       dist: trusty
       env: DEFINITION=5.6.40
-      addons:
-        apt:
-          packges:
-            - php5-cli
     - os: linux
       dist: trusty
       env: DEFINITION=7.0.33
@@ -118,9 +73,6 @@ before_install:
         if [[ "$DEFINITION" =~ ^("5.2.".*)$ ]]; then
             export PHP_BUILD_CONFIGURE_OPTS="--with-libdir=lib/x86_64-linux-gnu"
         fi
-        if [[ "$DEFINITION" =~ ^("5.2.".*|"5.3.".*)$ ]]; then
-            sudo apt-get install -y autoconf2.13
-        fi
         if [[ "$DEFINITION" =~ ^("7.3.".*)$ ]]; then
             export PHP_BUILD_CONFIGURE_OPTS="--without-libzip"
         fi
@@ -138,10 +90,6 @@ before_install:
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        if [[ "$DEFINITION" =~ ^("5.3.".*)$ ]]; then
-            brew install autoconf@2.13
-            export LIBS="-lssl -lcrypto"
-        fi
         if [[ "$DEFINITION" =~ ^("5.".*)$ ]]; then
             ./build-openssl-1.0.sh
             export PHP_BUILD_CONFIGURE_OPTS="$PHP_BUILD_CONFIGURE_OPTS --with-openssl=/usr/local/opt/openssl@1.0"
@@ -157,6 +105,7 @@ before_install:
         fi
     fi
 install:
+  - ./install-dependencies.sh
   - git clone https://github.com/sstephenson/bats
   - bats/install.sh $HOME
   - export PATH=$HOME/bin:$HOME/libexec:$PATH

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+set -e
+
+if [ -f /etc/debian_version ]; then
+	DISTRO=debian
+elif [ -f /etc/redhat-release ]; then
+	DISTRO=rhel
+elif [ "$(uname -s)" = "Darwin" ]; then
+	DISTRO=darwin
+else
+	echo "Unsupported operating system"
+	exit 1
+fi
+
+if command -v sudo; then
+	SUDO=sudo
+else
+	SUDO=
+fi
+
+# NOTES:
+#   * --with-libedit can be used to replace libreadline-dev with libedit-dev
+#   * libcurl4-openssl-dev may be used with PHP 5.6 or higher, but it will conflict
+#     with custom openssl 1.0.2 builds required for PHP 5.5 and lower.
+
+case $DISTRO in
+	debian)
+		export DEBIAN_FRONTEND=nointeractive
+		$SUDO apt-get update -q
+		$SUDO apt-get install -q -y --no-install-recommends \
+			autoconf2.13 \
+			autoconf2.64 \
+			autoconf \
+			bash \
+			bison \
+			build-essential \
+			ca-certificates \
+			curl \
+			findutils \
+			git \
+			libbz2-dev \
+			libcurl4-gnutls-dev \
+			libicu-dev \
+			libjpeg-dev \
+			libmcrypt-dev \
+			libonig-dev \
+			libpng-dev \
+			libreadline-dev \
+			libsqlite3-dev \
+			libssl-dev \
+			libtidy-dev \
+			libxml2-dev \
+			libxslt1-dev \
+			libzip-dev \
+			pkg-config \
+			re2c \
+			zlib1g-dev
+		;;
+	rhel)
+		$SUDO yum install -y yum-utils epel-release
+		$SUDO yum-config-manager --enable PowerTools
+		$SUDO yum install -y \
+			autoconf \
+			autoconf213 \
+			bash \
+			bison \
+			bzip2 \
+			bzip2-devel \
+			curl \
+			diffutils \
+			findutils \
+			gcc \
+			gcc-c++ \
+			git \
+			libcurl-devel \
+			libicu-devel \
+			libjpeg-turbo-devel \
+			libmcrypt-devel \
+			libpng-devel \
+			libtidy-devel \
+			libxml2-devel \
+			libxslt-devel \
+			libzip-devel \
+			make \
+			oniguruma-devel \
+			openssl-devel \
+			patch \
+			pkgconf \
+			readline-devel \
+			sqlite-devel \
+			zlib-devel
+		;;
+	darwin)
+		# brew install will fail if a package is already installed
+		# using brew bundle seems to be the recommended alternative
+		# https://github.com/Homebrew/brew/issues/2491
+		brew bundle --file=- <<-EOS
+brew "autoconf"
+brew "autoconf@2.13"
+brew "bzip2"
+brew "icu4c"
+brew "libedit"
+brew "libiconv"
+brew "libjpeg"
+brew "libmcrypt"
+brew "libxml2"
+brew "libzip"
+brew "oniguruma"
+brew "openssl"
+brew "pkg-config"
+brew "python"
+brew "re2c"
+brew "tidy-html5"
+brew "zlib"
+EOS
+		;;
+	*)
+esac


### PR DESCRIPTION
install-dependencies.sh installs all dependencies required to build PHP
with the default php-build options. Tested with Ubuntu (14.04, 16.04,
18.04, 20.04), CentOS (7, 8) and macOS (10.13, 10.15) with Homebrew.

This script is meant to be used both by continuous integration as well
as end users.