### PR TITLE
Improve openssl 1.0.2 build

### DIFF
--- a/build-openssl-1.0.sh
+++ b/build-openssl-1.0.sh
@@ -1,9 +1,53 @@
-#!/bin/sh -xe
+#!/bin/sh
+#
+# PHP 5.6 and older require OpenSSL 1.0.2, which is too old for most modern
+# operating systems. This script downloads, builds and installs OpenSSL 1.0.2
+# for use in PHP builds.
+#
 
-mkdir -p /tmp/openssl-1.0
-cd /tmp/openssl-1.0
-curl -Ls https://github.com/openssl/openssl/archive/OpenSSL_1_0_2t.tar.gz | tar xzC /tmp/openssl-1.0 --strip-components=1
-./Configure --prefix=/usr/local/opt/openssl@1.0 no-ssl2 no-ssl3 no-zlib shared enable-cms darwin64-x86_64-cc enable-ec_nistp_64_gcc_128
+set -ex
+
+BUILD_DIR=/tmp/openssl-1.0.2-build
+TARBALL=openssl-1.0.2t.tar.gz
+MD5SUM=ef66581b80f06eae42f5268bc0b50c6d
+PREFIX=/usr/local/opt/openssl@1.0
+
+if command -v sudo ; then
+	SUDO=sudo
+else
+	SUDO=
+fi
+
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+curl -OLs https://www.openssl.org/source/$TARBALL
+
+if command -v md5sum; then
+	echo "$MD5SUM $TARBALL" | md5sum -c
+fi
+
+tar xzf $TARBALL --strip-components=1 -C "$BUILD_DIR"
+
+CONFIG_SCRIPT=./config
+ARCH_ARGS=""
+if [ "$(uname -s)" = Darwin ] && [ "$(uname -m)" = x86_64 ]; then
+	ARCH_ARGS="darwin64-x86_64-cc enable-ec_nistp_64_gcc_128"
+	CONFIG_SCRIPT=./Configure
+fi
+
+$CONFIG_SCRIPT -fPIC shared no-ssl2 no-ssl3 no-zlib $ARCH_ARGS --prefix=/usr/local/opt/openssl@1.0
+
 make depend
-make
-sudo make install_sw
+
+make -j $(nproc)
+
+$SUDO make install_sw
+
+# if this multiarch system uses lib64, create a symlink for it
+# this will ensure that PHP configure script will succeed with any
+# combination of --with-openssl and --with-libdir
+if [ -d /usr/lib64 ]; then
+	$SUDO ln -s "$PREFIX/lib" "$PREFIX/lib64"
+fi
+
+rm -rf "$BUILD_DIR"


### PR DESCRIPTION
* Check md5sum to avoid corrupted downloads.

* Update to latest OpenSSL 1.0.2 release (1.0.2t).

* Run config script with defaults (works in Ubuntu, CentOS and macOS).

* Build with make -j $(nproc), using all available CPUs.

* Clean up build directory after install.

* Invoke 'sudo' only if it exists. Otherwise, we might be in a Docker
  container, Alpine Linux, etc, running as root.