### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: ci
+on:
+  pull_request:
+  push:
+jobs:
+  test-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - 'centos:7'
+          - 'centos:8'
+          - 'ubuntu:18.04'
+          - 'ubuntu:20.04'
+        php:
+          - '5.2.17'
+          - '5.3.29'
+          - '5.4.45'
+          - '5.5.38'
+          - '5.6.40'
+          - '7.0.33'
+          - '7.1.33'
+          - '7.2.33'
+          - '7.3.22'
+          - '7.4.10'
+        exclude:
+          # TODO: libmysqlclient-dev dependency
+          - { distro: 'centos:7', php: '5.2.17'}
+          # TODO: libmysqlclient-dev dependency & curl-config
+          - { distro: 'centos:8', php: '5.2.17'}
+          - { distro: 'ubuntu:18.04', php: '5.2.17'}
+          - { distro: 'ubuntu:20.04', php: '5.2.17'}
+          # TODO: curl-config
+          - { distro: 'ubuntu:18.04', php: '5.3.29'}
+          - { distro: 'ubuntu:18.04', php: '5.4.45'}
+          - { distro: 'ubuntu:18.04', php: '5.5.38'}
+          - { distro: 'ubuntu:18.04', php: '5.6.40'}
+          - { distro: 'ubuntu:20.04', php: '5.3.29'}
+          - { distro: 'ubuntu:20.04', php: '5.4.45'}
+          - { distro: 'ubuntu:20.04', php: '5.5.38'}
+          - { distro: 'ubuntu:20.04', php: '5.6.40'}
+          # TODO: icu-config / intl
+          - { distro: 'ubuntu:20.04', php: '7.0.33'}
+          # TODO: openssl 1.0.2
+          - { distro: 'centos:8', php: '5.3.29'}
+          - { distro: 'centos:8', php: '5.4.45'}
+          - { distro: 'centos:8', php: '5.5.38'}
+          # libzip (0.10.1) on CentOS 7 is too old for PHP 7.3+ (required: >= 0.11)
+          - { distro: 'centos:7', php: '7.3.22'}
+          - { distro: 'centos:7', php: '7.4.10'}
+    name: "test (php-${{ matrix.php }}, ${{ matrix.distro }})"
+    container: "${{ matrix.distro }}"
+    env:
+      # https://bugs.php.net/bug.php?id=79445
+      PHP_BUILD_CURL_OPTS: '--retry 3 --retry-delay 5 --connect-timeout 10'
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          set -ex
+          ./install-dependencies.sh
+          git clone --depth 1 https://github.com/sstephenson/bats.git
+          ./bats/install.sh /usr/local
+      - name: run tests
+        run: |
+          set -ex
+          if ! ./run-tests.sh ${{ matrix.php }}; then
+            cat /tmp/php-build.*.log
+            exit 1
+          fi


### PR DESCRIPTION
GitHub Actions can run far more parallel jobs than Travis (20 for free accounts, 40 for pro accounts). As far as I can tell, each individual GitHub worker has similar performance for Linux jobs, but is 2x faster for macOS jobs. So this enables testing of far more PHP+OS version combinations in less time.

Travis may still be useful in some cases that are not supported by GitHub Actions, such as alternative macOS versions (anything that is not latest stable version) or alternative architectures (arm64, ppc64le and s390x).

This PR adds GitHub Actions workflow for a few CentOS (7, 8) and Ubuntu (18.04) versions that currently work out of the box. The end goal would be combining GitHub Actions and Travis to test, at least, two latest stable versions of CentOS, Ubuntu and macOS combined with every supported PHP version on amd64. A few extra combinations could be supported later (e.g. latest PHP on latest Arch Linux or Alpine). All Linux builds would run on GitHub Actions, while macOS builds for versions other than 10.15.5 would run on Travis.

Regarding implementation, it uses Docker for Linux builds and tries to keep as much build logic out of CI files, opting for actual fixes to php-build when possible. Compiling old OpenSSL would be one of the exceptions.

~The PR currently depends on #635. I will rebase and convert to non-draft once #635 is merged.~

Further PRs will add fixes for that enable support on Ubuntu 20.04 and macOS 10.15.5.

