### PR TITLE
Revert all PHP versions lower than 8.0 to Xdebug 2.9

### DIFF
--- a/share/php-build/definitions/7.2.0
+++ b/share/php-build/definitions/7.2.0
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.0.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.1
+++ b/share/php-build/definitions/7.2.1
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.1.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.10
+++ b/share/php-build/definitions/7.2.10
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.10.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.11
+++ b/share/php-build/definitions/7.2.11
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.11.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.12
+++ b/share/php-build/definitions/7.2.12
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.12.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.13
+++ b/share/php-build/definitions/7.2.13
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.13.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.14
+++ b/share/php-build/definitions/7.2.14
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.14.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.15
+++ b/share/php-build/definitions/7.2.15
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.15.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.16
+++ b/share/php-build/definitions/7.2.16
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.16.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.17
+++ b/share/php-build/definitions/7.2.17
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.17.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.18
+++ b/share/php-build/definitions/7.2.18
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.18.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.19
+++ b/share/php-build/definitions/7.2.19
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.19.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.2
+++ b/share/php-build/definitions/7.2.2
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.2.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.20
+++ b/share/php-build/definitions/7.2.20
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.20.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.21
+++ b/share/php-build/definitions/7.2.21
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.21.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.22
+++ b/share/php-build/definitions/7.2.22
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.22.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.23
+++ b/share/php-build/definitions/7.2.23
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.23.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.24
+++ b/share/php-build/definitions/7.2.24
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.24.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.25
+++ b/share/php-build/definitions/7.2.25
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.25.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.26
+++ b/share/php-build/definitions/7.2.26
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.26.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.27
+++ b/share/php-build/definitions/7.2.27
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.27.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.28
+++ b/share/php-build/definitions/7.2.28
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.28.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.29
+++ b/share/php-build/definitions/7.2.29
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.29.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.3
+++ b/share/php-build/definitions/7.2.3
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.3.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.30
+++ b/share/php-build/definitions/7.2.30
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.30.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.31
+++ b/share/php-build/definitions/7.2.31
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.31.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.32
+++ b/share/php-build/definitions/7.2.32
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.32.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.33
+++ b/share/php-build/definitions/7.2.33
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.33.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.34
+++ b/share/php-build/definitions/7.2.34
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.34.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.4
+++ b/share/php-build/definitions/7.2.4
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.4.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.5
+++ b/share/php-build/definitions/7.2.5
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.5.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.6
+++ b/share/php-build/definitions/7.2.6
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.6.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.7
+++ b/share/php-build/definitions/7.2.7
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.7.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.8
+++ b/share/php-build/definitions/7.2.8
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.8.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2.9
+++ b/share/php-build/definitions/7.2.9
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.2.9.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.2snapshot
+++ b/share/php-build/definitions/7.2snapshot
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package_from_github PHP-7.2
-install_xdebug_master "xdebug_3_0"
+install_xdebug_master "xdebug_2_9"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.0
+++ b/share/php-build/definitions/7.3.0
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.0.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.1
+++ b/share/php-build/definitions/7.3.1
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.1.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.10
+++ b/share/php-build/definitions/7.3.10
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.10.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.11
+++ b/share/php-build/definitions/7.3.11
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.11.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.12
+++ b/share/php-build/definitions/7.3.12
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.12.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.13
+++ b/share/php-build/definitions/7.3.13
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.13.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.14
+++ b/share/php-build/definitions/7.3.14
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.14.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.15
+++ b/share/php-build/definitions/7.3.15
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.15.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.16
+++ b/share/php-build/definitions/7.3.16
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.16.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.17
+++ b/share/php-build/definitions/7.3.17
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.17.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.18
+++ b/share/php-build/definitions/7.3.18
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.18.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.19
+++ b/share/php-build/definitions/7.3.19
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.19.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.2
+++ b/share/php-build/definitions/7.3.2
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.2.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.20
+++ b/share/php-build/definitions/7.3.20
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.20.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.21
+++ b/share/php-build/definitions/7.3.21
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.21.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.22
+++ b/share/php-build/definitions/7.3.22
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.22.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.23
+++ b/share/php-build/definitions/7.3.23
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.23.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.24
+++ b/share/php-build/definitions/7.3.24
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.24.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.25
+++ b/share/php-build/definitions/7.3.25
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.25.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.3
+++ b/share/php-build/definitions/7.3.3
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.3.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.4
+++ b/share/php-build/definitions/7.3.4
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.4.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.5
+++ b/share/php-build/definitions/7.3.5
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.5.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.6
+++ b/share/php-build/definitions/7.3.6
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.6.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.7
+++ b/share/php-build/definitions/7.3.7
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.7.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.8
+++ b/share/php-build/definitions/7.3.8
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.8.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3.9
+++ b/share/php-build/definitions/7.3.9
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package "https://secure.php.net/distributions/php-7.3.9.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.3snapshot
+++ b/share/php-build/definitions/7.3snapshot
@@ -5,5 +5,5 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 install_package_from_github PHP-7.3
-install_xdebug_master "xdebug_3_0"
+install_xdebug_master "xdebug_2_9"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.0
+++ b/share/php-build/definitions/7.4.0
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.0.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.1
+++ b/share/php-build/definitions/7.4.1
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.1.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.10
+++ b/share/php-build/definitions/7.4.10
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.10.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.11
+++ b/share/php-build/definitions/7.4.11
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.11.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.12
+++ b/share/php-build/definitions/7.4.12
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.12.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.13
+++ b/share/php-build/definitions/7.4.13
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.13.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.2
+++ b/share/php-build/definitions/7.4.2
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.2.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.3
+++ b/share/php-build/definitions/7.4.3
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.3.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.4
+++ b/share/php-build/definitions/7.4.4
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.4.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.5
+++ b/share/php-build/definitions/7.4.5
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.5.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.6
+++ b/share/php-build/definitions/7.4.6
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.6.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.7
+++ b/share/php-build/definitions/7.4.7
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.7.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.8
+++ b/share/php-build/definitions/7.4.8
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.8.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4.9
+++ b/share/php-build/definitions/7.4.9
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package "https://secure.php.net/distributions/php-7.4.9.tar.bz2"
-install_xdebug "3.0.0"
+install_xdebug "2.9.8"
 enable_builtin_opcache

--- a/share/php-build/definitions/7.4snapshot
+++ b/share/php-build/definitions/7.4snapshot
@@ -3,5 +3,5 @@ configure_option "--with-jpeg"
 configure_option "--with-zip"
 
 install_package_from_github PHP-7.4
-install_xdebug_master "xdebug_3_0"
+install_xdebug_master "xdebug_2_9"
 enable_builtin_opcache


### PR DESCRIPTION
This PR reverts the update of Xdebug to version 3 that I did in #650 on all PHP versions lower than 8.0. While Travis CI luckily did not rebuilt their existing images, it published the new ones that did get the upgrade in ac92f4e0e8a5860f663c2ece71123500a0db73d2 and this caused all projects that were running fine with Xdebug 2 and PHPUnit 7 to broke unexpectly