### PR TITLE
Fixed installing extensions from source ref which is not on the 'mast…

### DIFF
--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -115,7 +115,7 @@ function _checkout_extension {
         cd "$source_dir"
         git clean -fdx
         git reset --hard HEAD
-        git pull origin master > /dev/null
+        git pull origin > /dev/null
         cd "$cwd"
     else
         log "$name" "Fetching from $url_source"

--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -115,12 +115,16 @@ function _checkout_extension {
         cd "$source_dir"
         git clean -fdx
         git reset --hard HEAD
-        git pull origin > /dev/null
+        git fetch origin > /dev/null
         cd "$cwd"
     else
         log "$name" "Fetching from $url_source"
         git clone "$url_source" "$source_dir" 2>&4
         log "$name" "commit $(cd ${source_dir} && git rev-parse HEAD)"
+    fi
+
+    if [ ! -n "$revision" ]; then
+        revision="origin/master"
     fi
 
     if [ -n "$revision" ]; then


### PR DESCRIPTION
…er' branch

this happens if the ref points to a non-primary branch, or, as is becoming more common, a primary branch which is not called 'master'.