### PR TITLE
Add PHP 8.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - '7.3.31'
           - '7.4.24'
           - '8.0.11'
+          - '8.1snapshot'
         exclude:
           # TODO: libmysqlclient-dev dependency
           - { distro: 'centos:7', php: '5.2.17'}


### PR DESCRIPTION
Any idea why it fails? https://github.com/simPod/php-build/runs/3846331760