### PR TITLE
Fixing ZTS (and some other stuff) on 8.1 (again)

### DIFF
--- a/bin/php-build
+++ b/bin/php-build
@@ -656,11 +656,9 @@ function configure_package() {
     local minorVersion=$(echo $baseVersion | cut -d '.' -f2)
 
     if [[ $majorVersion -ge 8 ]]; then
-	phpLower74=false
-	phpLower80=false
-	log Debug "PHP version detected as 8 or higher"
+        phpLower74=false
+        phpLower80=false
     elif [[ $majorVersion -eq 7 ]] && [[ $minorVersion -ge 4 ]]; then
-	log Debug "PHP version detected as 7.4 or higher"
         phpLower74=false
     fi
 


### PR DESCRIPTION
The code to check for 7.4/8.0 or higher wasn't very robust, and was equivalent to checking `version == 7.4` or `version == 8.0`.

This properly fixes said checks so that stuff works as expected on 8.1 and above (including on snapshots, RCs, and whatever else).
In theory, this won't need to be fixed again.