### PR TITLE
Use https git URL to clone from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Locate your phpenv directory:
 
 Clone the Git repository into phpenv plugins directory:
 
-    % git clone git://github.com/php-build/php-build.git $HOME/.phpenv/plugins/php-build
+    % git clone https://github.com/php-build/php-build.git $HOME/.phpenv/plugins/php-build
 
 Now you can use php-build as phpenv plugin, as follows:
 
@@ -47,7 +47,7 @@ The built version will be installed into `$HOME/.phpenv/versions/<definition>`.
 
 Clone the Git Repository:
 
-    % git clone git://github.com/php-build/php-build.git
+    % git clone https://github.com/php-build/php-build.git
 
 Then go into the extracted/cloned directory and run:
 

--- a/share/php-build/extension/definition
+++ b/share/php-build/extension/definition
@@ -7,6 +7,6 @@
 "memcached","http://pecl.php.net/get/memcached-$version.tgz","https://github.com/php-memcached-dev/php-memcached.git",,"--disable-memcached-sasl","extension",
 "uprofiler",,"https://github.com/FriendsOfPHP/uprofiler.git","extension",,"extension","uprofiler_after_install"
 "xcache","http://xcache.lighttpd.net/pub/Releases/$version/xcache-$version.tar.gz",,,"--enable-xcache","extension",
-"xdebug","http://xdebug.org/files/xdebug-$version.tgz","git://github.com/xdebug/xdebug.git",,"--enable-xdebug","zend_extension","xdebug_after_install"
-"xhprof","http://pecl.php.net/get/xhprof-$version.tgz","git://github.com/facebook/xhprof.git",,,"extension","xhprof_after_install"
+"xdebug","http://xdebug.org/files/xdebug-$version.tgz","https://github.com/xdebug/xdebug.git",,"--enable-xdebug","zend_extension","xdebug_after_install"
+"xhprof","http://pecl.php.net/get/xhprof-$version.tgz","https://github.com/facebook/xhprof.git",,,"extension","xhprof_after_install"
 "zendopcache","http://pecl.php.net/get/zendopcache-$version.tgz","https://github.com/zendtech/ZendOptimizerPlus.git",,"--enable-opcache","zend_extension","zendopcache_after_install"

--- a/share/php-build/plugins.d/github.sh
+++ b/share/php-build/plugins.d/github.sh
@@ -35,7 +35,7 @@ function download_from_github() {
 function clone_from_github() {
     local branch=${1}
     local repository_name=${2}
-    local repository_url="git://github.com/${repository_name}.git"
+    local repository_url="https://github.com/${repository_name}.git"
     local directory="${PHP_BUILD_TMPDIR}/source/${DEFINITION}"
 
     if [ -d "${directory}" ]; then


### PR DESCRIPTION
This PR changes the use of the unencrypted `git` protocol to `https` as `git://` has been disabled.
More info: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Build error:
```bash
  [Cloning]: Branch PHP-8.1 from git://github.com/php/php-src.git
  fatal: remote error: 
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
  ```