### PR TITLE
Compatfix: ignore phpenv-hooks for CHH/phpenv

### DIFF
--- a/bin/phpenv-uninstall
+++ b/bin/phpenv-uninstall
@@ -66,7 +66,7 @@ after_uninstall() {
 # run user-defined hooks defined in $PHPENV_ROOT/phpenv.d/uninstall
 # and phpenv plugin-defined hooks in $PLUGIN_ROOT/etc/phpenv.d/uninstall
 OLDIFS="$IFS"
-IFS=$'\n' scripts=(`phpenv-hooks uninstall`)
+IFS=$'\n' scripts=(`type phpenv-hooks >/dev/null 2>&1 && phpenv-hooks install || true`)
 IFS="$OLDIFS"
 for script in "${scripts[@]}"; do source "$script"; done
 


### PR DESCRIPTION
Apply same fix as #520.