### PR TITLE
Fix install-dependencies.sh for CentOS 8

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -61,6 +61,11 @@ case $DISTRO in
 			zlib1g-dev
 		;;
 	rhel)
+		# NOTE: Responding to the following error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
+		if [ ${VERSION_ID:-0} -eq 8 ]; then
+			sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+			sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+		fi
 		$SUDO yum install -y yum-utils epel-release
 		if [ ${VERSION_ID:-0} -lt 8 ]; then
 			$SUDO yum-config-manager --enable PowerTools


### PR DESCRIPTION
Since CentOS 8 became EOL on December 31st, 2021 the test of CentOS 8 did not pass, so I fixed the reference of the yum repository for CentOS 8 in install-dependencies.sh.

CentOS 8 has become EOL, so I'm thinking about quitting CentOS 8 and switching to Rocky Linux 8. (It will be supported by another PR.)

Thank you.

# Refs

- Failed test: https://github.com/dounokouno/php-build/actions/runs/1850327369
- Passed test: https://github.com/dounokouno/php-build/actions/runs/1851779142