### PR TITLE
Fix build os from centos 8 to rockylinyx 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         distro:
           - 'centos:7'
-          - 'centos:8'
+          - 'rockylinux:8'
           - 'ubuntu:18.04'
           - 'ubuntu:20.04'
         php:
@@ -30,7 +30,7 @@ jobs:
           # TODO: libmysqlclient-dev dependency
           - { distro: 'centos:7', php: '5.2.17'}
           # TODO: libmysqlclient-dev dependency & curl-config
-          - { distro: 'centos:8', php: '5.2.17'}
+          - { distro: 'rockylinux:8', php: '5.2.17'}
           - { distro: 'ubuntu:18.04', php: '5.2.17'}
           - { distro: 'ubuntu:20.04', php: '5.2.17'}
           # TODO: curl-config
@@ -45,9 +45,9 @@ jobs:
           # TODO: icu-config / intl
           - { distro: 'ubuntu:20.04', php: '7.0.33'}
           # TODO: openssl 1.0.2
-          - { distro: 'centos:8', php: '5.3.29'}
-          - { distro: 'centos:8', php: '5.4.45'}
-          - { distro: 'centos:8', php: '5.5.38'}
+          - { distro: 'rockylinux:8', php: '5.3.29'}
+          - { distro: 'rockylinux:8', php: '5.4.45'}
+          - { distro: 'rockylinux:8', php: '5.5.38'}
     name: "test (php-${{ matrix.php }}, ${{ matrix.distro }})"
     container: "${{ matrix.distro }}"
     env:

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -61,11 +61,6 @@ case $DISTRO in
 			zlib1g-dev
 		;;
 	rhel)
-		# NOTE: Responding to the following error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
-		if [ ${VERSION_ID:-0} -eq 8 ]; then
-			sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
-			sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
-		fi
 		$SUDO yum install -y yum-utils epel-release
 		if [ ${VERSION_ID:-0} -lt 8 ]; then
 			$SUDO yum-config-manager --enable PowerTools


### PR DESCRIPTION
Since CentOS 8 went EOL on December 31st 2021, I stopped using CentOS 8 and switched to Rocky Linux 8. Confirm it.

Refs: #705

Thank you.