### PR TITLE
Remove support of php-build for CentOS 7 and Ubuntu 18, and add support for Ubuntu 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           - 'rockylinux:9'
           - 'ubuntu:20.04'
           - 'ubuntu:22.04'
+          - 'ubuntu:24.04'
         php:
           - '5.2.17'
           - '5.3.29'
@@ -34,37 +35,46 @@ jobs:
           - { distro: 'rockylinux:9', php: '5.2.17'}
           - { distro: 'ubuntu:20.04', php: '5.2.17'}
           - { distro: 'ubuntu:22.04', php: '5.2.17'}
+          - { distro: 'ubuntu:24.04', php: '5.2.17'}
           # PHP 5.3
           - { distro: 'rockylinux:8', php: '5.3.29'}
           - { distro: 'rockylinux:9', php: '5.3.29'}
           - { distro: 'ubuntu:20.04', php: '5.3.29'}
           - { distro: 'ubuntu:22.04', php: '5.3.29'}
+          - { distro: 'ubuntu:24.04', php: '5.3.29'}
           # PHP 5.4
           - { distro: 'rockylinux:8', php: '5.4.45'}
           - { distro: 'rockylinux:9', php: '5.4.45'}
           - { distro: 'ubuntu:20.04', php: '5.4.45'}
           - { distro: 'ubuntu:22.04', php: '5.4.45'}
+          - { distro: 'ubuntu:24.04', php: '5.4.45'}
           # PHP 5.5
           - { distro: 'rockylinux:8', php: '5.5.38'}
           - { distro: 'rockylinux:9', php: '5.5.38'}
           - { distro: 'ubuntu:20.04', php: '5.5.38'}
           - { distro: 'ubuntu:22.04', php: '5.5.38'}
+          - { distro: 'ubuntu:24.04', php: '5.5.38'}
           # PHP 5.6
           - { distro: 'rockylinux:9', php: '5.6.40'}
           - { distro: 'ubuntu:20.04', php: '5.6.40'}
           - { distro: 'ubuntu:22.04', php: '5.6.40'}
+          - { distro: 'ubuntu:24.04', php: '5.6.40'}
           # PHP 7.0
           - { distro: 'rockylinux:9', php: '7.0.33'}
           - { distro: 'ubuntu:20.04', php: '7.0.33'}
           - { distro: 'ubuntu:22.04', php: '7.0.33'}
+          - { distro: 'ubuntu:24.04', php: '7.0.33'}
           # PHP 7.1
           - { distro: 'rockylinux:9', php: '7.1.33'}
           - { distro: 'ubuntu:22.04', php: '7.1.33'}
+          - { distro: 'ubuntu:24.04', php: '7.1.33'}
           # PHP 7.2
           - { distro: 'rockylinux:9', php: '7.2.34'}
           - { distro: 'ubuntu:22.04', php: '7.2.34'}
+          - { distro: 'ubuntu:24.04', php: '7.2.34'}
           # PHP 7.3
           - { distro: 'ubuntu:22.04', php: '7.3.33'}
+          - { distro: 'ubuntu:24.04', php: '7.3.33'}
           # PHP 8.3
           - { distro: 'rockylinux:8', php: '8.3.8'}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       # https://bugs.php.net/bug.php?id=79445
       PHP_BUILD_CURL_OPTS: '--retry 3 --retry-delay 5 --connect-timeout 10'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
           set -ex

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
         distro:
           - 'rockylinux:8'
           - 'rockylinux:9'
-          - 'ubuntu:18.04'
           - 'ubuntu:20.04'
           - 'ubuntu:22.04'
         php:
@@ -33,30 +32,25 @@ jobs:
           # PHP 5.2
           - { distro: 'rockylinux:8', php: '5.2.17'}
           - { distro: 'rockylinux:9', php: '5.2.17'}
-          - { distro: 'ubuntu:18.04', php: '5.2.17'}
           - { distro: 'ubuntu:20.04', php: '5.2.17'}
           - { distro: 'ubuntu:22.04', php: '5.2.17'}
           # PHP 5.3
           - { distro: 'rockylinux:8', php: '5.3.29'}
           - { distro: 'rockylinux:9', php: '5.3.29'}
-          - { distro: 'ubuntu:18.04', php: '5.3.29'}
           - { distro: 'ubuntu:20.04', php: '5.3.29'}
           - { distro: 'ubuntu:22.04', php: '5.3.29'}
           # PHP 5.4
           - { distro: 'rockylinux:8', php: '5.4.45'}
           - { distro: 'rockylinux:9', php: '5.4.45'}
-          - { distro: 'ubuntu:18.04', php: '5.4.45'}
           - { distro: 'ubuntu:20.04', php: '5.4.45'}
           - { distro: 'ubuntu:22.04', php: '5.4.45'}
           # PHP 5.5
           - { distro: 'rockylinux:8', php: '5.5.38'}
           - { distro: 'rockylinux:9', php: '5.5.38'}
-          - { distro: 'ubuntu:18.04', php: '5.5.38'}
           - { distro: 'ubuntu:20.04', php: '5.5.38'}
           - { distro: 'ubuntu:22.04', php: '5.5.38'}
           # PHP 5.6
           - { distro: 'rockylinux:9', php: '5.6.40'}
-          - { distro: 'ubuntu:18.04', php: '5.6.40'}
           - { distro: 'ubuntu:20.04', php: '5.6.40'}
           - { distro: 'ubuntu:22.04', php: '5.6.40'}
           # PHP 7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - 'centos:7'
           - 'rockylinux:8'
           - 'rockylinux:9'
           - 'ubuntu:18.04'
@@ -32,7 +31,6 @@ jobs:
           - '8.3.8'
         exclude:
           # PHP 5.2
-          - { distro: 'centos:7', php: '5.2.17'}
           - { distro: 'rockylinux:8', php: '5.2.17'}
           - { distro: 'rockylinux:9', php: '5.2.17'}
           - { distro: 'ubuntu:18.04', php: '5.2.17'}
@@ -73,10 +71,7 @@ jobs:
           - { distro: 'ubuntu:22.04', php: '7.2.34'}
           # PHP 7.3
           - { distro: 'ubuntu:22.04', php: '7.3.33'}
-          # PHP 8.2
-          - { distro: 'centos:7', php: '8.2.20'}
           # PHP 8.3
-          - { distro: 'centos:7', php: '8.3.8'}
           - { distro: 'rockylinux:8', php: '8.3.8'}
 
     name: "test (php-${{ matrix.php }}, ${{ matrix.distro }})"

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -61,18 +61,18 @@ case $DISTRO in
 			zlib1g-dev
 		;;
 	rhel)
-		$SUDO yum install -y yum-utils epel-release
+		$SUDO dnf install -y yum-utils epel-release
 		if [[ "$VERSION_ID" =~ ^8 ]]; then
-			$SUDO yum install -y dnf-plugins-core
-			$SUDO yum config-manager --set-enabled powertools
-			$SUDO yum install -y autoconf autoconf213
+			$SUDO dnf install -y dnf-plugins-core
+			$SUDO dnf config-manager --set-enabled powertools
+			$SUDO dnf install -y autoconf autoconf213
 		else
-			$SUDO yum install -y dnf-plugins-core
-			$SUDO yum config-manager --set-enabled crb
+			$SUDO dnf install -y dnf-plugins-core
+			$SUDO dnf config-manager --set-enabled crb
 			$SUDO dnf -y swap curl-minimal curl
-			$SUDO yum install -y autoconf
+			$SUDO dnf install -y autoconf
 		fi
-		$SUDO yum install -y \
+		$SUDO dnf install -y \
 			bash \
 			bison \
 			bzip2 \

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -62,17 +62,7 @@ case $DISTRO in
 		;;
 	rhel)
 		$SUDO yum install -y yum-utils epel-release
-		if [[ "$VERSION_ID" =~ ^7 ]]; then
-			$SUDO yum-config-manager --enable PowerTools
-			# Install gcc v10 and enable it
-			$SUDO yum install -y centos-release-scl
-			$SUDO yum install -y devtoolset-10-gcc-c++
-			# Countermeasures for the message on the right: "MANPATH: unbound variable"
-			MANPATH=""
-			# Enable devtoolset-10 for gcc v10
-			source /opt/rh/devtoolset-10/enable
-			$SUDO yum install -y autoconf autoconf213
-		elif [[ "$VERSION_ID" =~ ^8 ]]; then
+		if [[ "$VERSION_ID" =~ ^8 ]]; then
 			$SUDO yum install -y dnf-plugins-core
 			$SUDO yum config-manager --set-enabled powertools
 			$SUDO yum install -y autoconf autoconf213


### PR DESCRIPTION
Hi,

Vendor support for CentOS 7 will end on June 30, 2024, and for Ubuntu 18 on May 31, 2023. I think that it would be fine for php-build to not support operating systems for which vendor support has ended.

Also, Ubuntu 22.04 was released on Feb 22, 2024, I added support for it to php-build. (If it is better to separate the discussion from the above, I would like to separate the PR.)

Merging this PR will likely allow GitHub Actions for other PRs (e.g. #775) that add new PHP versions to go through.

If you have any concerns, please feel free to comment.