### PR TITLE
Add patch for php 7.3.33

### DIFF
--- a/share/php-build/definitions/7.3.33
+++ b/share/php-build/definitions/7.3.33
@@ -5,6 +5,7 @@ configure_option "--with-jpeg-dir" "/usr"
 configure_option "--enable-zip"
 
 patch_file "php-8.0-support-openssl-3.patch"
+patch_file "php-7.3-openssl.patch"
 
 install_package "https://secure.php.net/distributions/php-7.3.33.tar.bz2"
 install_xdebug "3.1.6"

--- a/share/php-build/patches/php-7.3-openssl.patch
+++ b/share/php-build/patches/php-7.3-openssl.patch
@@ -1,0 +1,41 @@
+--- a/ext/intl/locale/locale_methods.c
++++ b/ext/intl/locale/locale_methods.c
+@@ -1326,7 +1326,7 @@ PHP_FUNCTION(locale_filter_matches)
+ 		if( token && (token==cur_lang_tag) ){
+ 			/* check if the char. after match is SEPARATOR */
+ 			chrcheck = token + (strlen(cur_loc_range));
+-			if( isIDSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
++			if( isIDSeparator(*chrcheck) || isKeywordSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
+ 				efree( cur_lang_tag );
+ 				efree( cur_loc_range );
+ 				if( can_lang_tag){
+--- a/ext/intl/breakiterator/codepointiterator_internal.cpp
++++ b/ext/intl/breakiterator/codepointiterator_internal.cpp
+@@ -75,7 +75,11 @@
+ 	clearCurrentCharIter();
+ }
+
+-UBool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++ bool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#else
++ UBool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#endif
+ {
+ 	if (typeid(*this) != typeid(that)) {
+ 		return FALSE;
+--- a/ext/intl/breakiterator/codepointiterator_internal.h
++++ b/ext/intl/breakiterator/codepointiterator_internal.h
+@@ -39,7 +39,11 @@
+
+ 		virtual ~CodePointBreakIterator();
+
+-		virtual UBool operator==(const BreakIterator& that) const;
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++		virtual bool operator==(const BreakIterator& that) const;
++#else
++ 		virtual UBool operator==(const BreakIterator& that) const;
++#endif
+
+ 		virtual CodePointBreakIterator* clone(void) const;
+


### PR DESCRIPTION
Allows for php 7.3 to be compiled 

Based on the changes from https://github.com/php/php-src/pull/7596

```
CFLAGS="-Wno-deprecated-declarations" PHP_BUILD_INSTALL_EXTENSION="libsodium=1.0.7" phpenv install 7.3.33
```

```
|#10 102.7
------
102.7 In file included from /tmp/php-build/source/7.3.33/ext/intl/breakiterator/codepointiterator_internal.h:20:
102.7 /usr/include/unicode/brkiter.h:127:18: note: overridden function is 'virtual bool icu_72::BreakIterator::operator==(const icu_72::BreakIterator&) const'
102.7   127 |     virtual bool operator==(const BreakIterator&) const = 0;
102.7       |                  ^~~~~~~~
102.7 make: *** [Makefile:1202: ext/intl/breakiterator/codepointiterator_methods.lo] Error 1
102.7 -----------------------------------------
102.7
102.7 The full Log is available at '/tmp/php-build.7.3.33.20250129151041.log'.
```