### PR TITLE
Remove rbenv-* executables

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -1,1 +1,0 @@
-phpenv-install

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -1,1 +1,0 @@
-phpenv-uninstall

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -1,1 +1,0 @@
-phpenv-update


### PR DESCRIPTION
This previously caused an issue 7 years ago when some users were still using now defunct CHH/phpenv which used rbenv names for the executables. php-build has been recommending the official phpenv project for at least 7 years now and no longer needs these symlinks.

Only issue (now closed) in relation:
https://github.com/php-build/php-build/issues/516
 - caused because users were using CHH/phpenv before official phpenv/phpenv was resumed
 - not an issue since 2018

rbenv symlinks have a very small possibility of conflicting with rbenv or similar tools if both are present in the wrong order.
