### PR TITLE
Added support for Arch Linux.

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -3,6 +3,9 @@ set -eu
 
 if [ -f /etc/os-release ]; then
 	. /etc/os-release
+    if [ "$NAME" == "Arch Linux" ]; then
+        DISTRO=arch
+    fi
 fi
 
 if [ -f /etc/debian_version ]; then
@@ -108,6 +111,33 @@ case $DISTRO in
 			make && \
 			make install
 		;;
+    arch)
+        $SUDO pacman -Syu
+        arch_dependencies=(
+            "autoconf"
+            "bison"
+            "ca-certificates"
+            "findutils"
+            "bzip2"
+            "libcurl-gnutls"
+            "icu"
+            "libmcrypt"
+            "oniguruma"
+            "libpng"
+            "readline"
+            "sqlite"
+            "openssl"
+            "tidy"
+            "libxml2"
+            "libxslt"
+            "libzip"
+            "re2c"
+            "zlib"
+        )
+        for d in "${arch_dependencies[@]}"; do
+            sudo pacman -S --needed "$d" --noconfirm
+        done
+        ;;
 	darwin)
 		# brew install will fail if a package is already installed
 		# using brew bundle seems to be the recommended alternative


### PR DESCRIPTION
Added a distro check via `/etc/os-release` and `pacman` dependencies for Arch Linux. Successfully built PHP 8.4.7 on both vanilla Arch running kernel 6.14.5, as well as WSL2 Arch running kernel 5.15.167.4.

I assume these dependencies will satisfy distros downstream from Arch, such as Manjaro, but I have not tested.