### PR TITLE
Added PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - '8.2.29'
           - '8.3.28'
           - '8.4.15'
+          - '8.5.0'
         exclude:
           # PHP 5.2
           - { distro: 'rockylinux:8', php: '5.2.17'}
@@ -80,6 +81,8 @@ jobs:
           - { distro: 'rockylinux:8', php: '8.3.28'}
           # PHP 8.4
           - { distro: 'rockylinux:8', php: '8.4.15'}
+          # PHP 8.5
+          - { distro: 'rockylinux:8', php: '8.5.0'}
 
     name: "test (php-${{ matrix.php }}, ${{ matrix.distro }})"
     container: "${{ matrix.distro }}"

--- a/share/php-build/definitions/8.5.0
+++ b/share/php-build/definitions/8.5.0
@@ -1,0 +1,10 @@
+configure_option "--enable-gd"
+configure_option "--with-jpeg"
+configure_option "--with-zip"
+configure_option "--with-mhash"
+
+configure_option -D "--with-xmlrpc"
+
+install_package "https://www.php.net/distributions/php-8.5.0.tar.bz2"
+install_xdebug "3.5.0"
+enable_builtin_opcache


### PR DESCRIPTION
Glad to see that this project is still maintained. I still use php-build in my builds almost every day. And since OSS means not only mean consuming, I present you my PR for PHP 8.5.

As Xdebug today released a stable version with PHP 8.5 support, I thought in would be time.

See you soon!
