### PR TITLE
Add ICU 74 and libxml2 2.12 compatibility patches for PHP 8.0 to fix installation error in OSX

### DIFF
--- a/share/php-build/definitions/8.0.0
+++ b/share/php-build/definitions/8.0.0
@@ -6,6 +6,8 @@ configure_option "--with-mhash"
 configure_option -D "--with-xmlrpc"
 
 patch_file "php-8.0-support-openssl-3.patch"
+patch_file "php-8.0-libxml2-2.12-compat.patch"
+patch_file "php-8.0-icu-74-compat.patch"
 
 install_package "https://secure.php.net/distributions/php-8.0.0.tar.bz2"
 install_xdebug "3.4.7"

--- a/share/php-build/patches/php-8.0-icu-74-compat.patch
+++ b/share/php-build/patches/php-8.0-icu-74-compat.patch
@@ -1,0 +1,28 @@
+--- a/ext/intl/breakiterator/codepointiterator_internal.h
++++ b/ext/intl/breakiterator/codepointiterator_internal.h
+@@ -37,7 +37,11 @@ namespace PHP {
+
+ 		virtual ~CodePointBreakIterator();
+
++#if U_ICU_VERSION_MAJOR_NUM >= 74
++		virtual bool operator==(const BreakIterator& that) const;
++#else
+ 		virtual UBool operator==(const BreakIterator& that) const;
++#endif
+
+ 		virtual CodePointBreakIterator* clone(void) const;
+
+--- a/ext/intl/breakiterator/codepointiterator_internal.cpp
++++ b/ext/intl/breakiterator/codepointiterator_internal.cpp
+@@ -49,7 +49,11 @@ CodePointBreakIterator::~CodePointBreakIterator()
+ 	clearCurrentCharIter();
+ }
+
++#if U_ICU_VERSION_MAJOR_NUM >= 74
++bool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#else
+ UBool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#endif
+ {
+ 	if (typeid(*this) != typeid(that)) {
+ 		return FALSE;

--- a/share/php-build/patches/php-8.0-libxml2-2.12-compat.patch
+++ b/share/php-build/patches/php-8.0-libxml2-2.12-compat.patch
@@ -1,0 +1,29 @@
+--- a/ext/libxml/libxml.c
++++ b/ext/libxml/libxml.c
+@@ -678,7 +678,7 @@ static void php_libxml_internal_error_handler(int error_type, const char *msg,
+
+ PHP_LIBXML_API void php_libxml_structured_error_handler(void *userData, xmlErrorPtr error)
+ {
+-	_php_list_set_error_structure(error, NULL);
++	_php_list_set_error_structure((xmlError *)error, NULL);
+
+ 	return;
+ }
+@@ -968,7 +968,7 @@ PHP_FUNCTION(libxml_use_internal_errors)
+ 			LIBXML(error_list) = NULL;
+ 		}
+ 	} else {
+-		xmlSetStructuredErrorFunc(NULL, php_libxml_structured_error_handler);
++		xmlSetStructuredErrorFunc(NULL, (xmlStructuredErrorFunc)php_libxml_structured_error_handler);
+ 		if (LIBXML(error_list) == NULL) {
+ 			LIBXML(error_list) = (zend_llist *) emalloc(sizeof(zend_llist));
+ 			zend_llist_init(LIBXML(error_list), sizeof(xmlError), _php_libxml_free_error, 0);
+@@ -985,7 +985,7 @@ PHP_FUNCTION(libxml_get_last_error)
+ 		return;
+ 	}
+
+-	error = xmlGetLastError();
++	error = (xmlError *)xmlGetLastError();
+
+ 	if (error) {
+ 		object_init_ex(return_value, libxmlerror_class_entry);


### PR DESCRIPTION
This pull request updates the PHP 8.0.0 build definition to improve compatibility with newer versions of its dependencies, specifically ICU 74 and libxml2 2.12. It introduces two new patch files and applies them during the build process to ensure successful compilation and correct behaviour with these updated libraries.

Dependency compatibility updates:

* Added and applied `php-8.0-libxml2-2.12-compat.patch` to address compatibility issues with libxml2 version 2.12, updating type casts and function signatures in `libxml.c` to match the new libxml2 API. [[1]](diffhunk://#diff-4a129e7ec8d8f54b8e04062ec98ce5699f72f12b62a50ef19fe036855c2a02b3R9-R10) [[2]](diffhunk://#diff-f7d85ef9f5389b6bb32699fdd1a75e5c33dbd8b318127b8b3b1b0581ee947798R1-R29)
* Added and applied `php-8.0-icu-74-compat.patch` to provide compatibility with ICU version 74, updating the `CodePointBreakIterator` class to use the correct return type for the equality operator based on the ICU version. [[1]](diffhunk://#diff-4a129e7ec8d8f54b8e04062ec98ce5699f72f12b62a50ef19fe036855c2a02b3R9-R10) [[2]](diffhunk://#diff-761fd87952eaf374cb65ba469d8dafddff3a8b5b3a6fd4e2ef2300b570c786f5R1-R28)