### PR TITLE
Fix undefined $cwd in _checkout_extension (build aborts with bash 5.3)

### DIFF
--- a/share/php-build/extension/extension.sh
+++ b/share/php-build/extension/extension.sh
@@ -109,6 +109,7 @@ function _checkout_extension {
     local extension_type="$6"
     local after_install="$7"
     local source_dir="$PHP_BUILD_TMPDIR/source/$name-master"
+    local cwd="$(pwd)"
 
     if [ -d "$source_dir" ] && [ -d "$source_dir/.git" ]; then
         log "$name" "Updating $name from Git Master"


### PR DESCRIPTION
Fixes #799.

`_checkout_extension()` restores the previous working directory with `cd "$cwd"`, but `$cwd` is never defined in that scope, so the command actually executed is `cd ""`.

Up to bash 5.2 that was a silent no-op. bash 5.3 makes `cd ""` an error as POSIX requires, and since php-build runs under `set -e` with an ERR trap, every extension installed from a git checkout (e.g. `install_xdebug_master`, used by the snapshot definitions) aborts the whole build right after PHP itself was installed — with nothing in the build log, because the definition is sourced without redirecting stderr there.

This one-line change defines `cwd` at the top of `_checkout_extension()`, matching what `_build_extension()` already does.

Verified on Fedora 44 / bash 5.3.9: `phpenv install 8.3snapshot`, `8.4snapshot` and `8.5snapshot` all build and install Xdebug again with this fix.